### PR TITLE
fix(tools): prevent path traversal and version injection in docs and api tools

### DIFF
--- a/src/tools/get_component_api/get_component_api.ts
+++ b/src/tools/get_component_api/get_component_api.ts
@@ -25,6 +25,12 @@ export const getComponentApiTool = {
   },
   handler: async ({ componentName, version = 'latest' }: GetComponentAPIToolPayload) => {
     try {
+      if (!/^[\da-zA-Z.\-]+$/.test(version)) {
+        return createTextResponse(
+          `Access denied: version "${version}" contains invalid characters. Use a semver string (e.g., "2.12.0") or "latest".`
+        );
+      }
+
       // transform any to kebab-case e.g avatar group (space) or
       // avatarGroup or AvatarGroup (camelCase) to avatar-group
       let normalizedName = componentName

--- a/src/tools/get_docs/get_doc.ts
+++ b/src/tools/get_docs/get_doc.ts
@@ -9,19 +9,22 @@ const DOCS_DIR = path.join(__dirname, '../../../docs');
 
 const docRequestSchema = z.object({
   path: z.string().describe('Document path (e.g., "docs/08-Releases.md")'),
-  lines: z.string().optional().describe('Line range like "1-24" or "26-58" (optional, reads full file if omitted)'),
+  lines: z
+    .string()
+    .optional()
+    .describe('Line range like "1-24" or "26-58" (optional, reads full file if omitted)'),
 });
 
 function readLines(filePath: string, lineRange?: string): string {
   const content = fs.readFileSync(filePath, 'utf8');
-  
+
   if (!lineRange) {
     return content;
   }
 
   const lines = content.split('\n');
-  const [start, end] = lineRange.split('-').map(n => parseInt(n.trim(), 10));
-  
+  const [start, end] = lineRange.split('-').map((n) => parseInt(n.trim(), 10));
+
   if (isNaN(start) || isNaN(end) || start < 1 || end < start) {
     throw new Error(`Invalid line range: ${lineRange}`);
   }
@@ -31,7 +34,8 @@ function readLines(filePath: string, lineRange?: string): string {
 
 export const getDocTool = {
   name: 'get_doc',
-  description: 'Get full content of UI5 Web Components documentation file(s). Supports reading multiple documents and specific line ranges.',
+  description:
+    'Get full content of UI5 Web Components documentation file(s). Supports reading multiple documents and specific line ranges.',
   inputSchema: {
     docs: z
       .array(docRequestSchema)
@@ -44,6 +48,12 @@ export const getDocTool = {
       for (const doc of docs) {
         const normalizedPath = doc.path.replace(/^docs\//, '');
         const filePath = path.join(DOCS_DIR, normalizedPath);
+        const resolvedPath = path.resolve(filePath);
+
+        if (!resolvedPath.startsWith(path.resolve(DOCS_DIR))) {
+          results.push(`Access denied: "${doc.path}" points outside the docs directory.`);
+          continue;
+        }
 
         if (!fs.existsSync(filePath)) {
           results.push(`❌ Document "${doc.path}" not found.`);
@@ -55,8 +65,9 @@ export const getDocTool = {
         results.push(`# ${doc.path}${rangeInfo}\n\n${content}`);
       }
 
-      const footer = '\n\n**Framework Integration:** If using React, Angular or Vue, also check the get_guidelines tool for framework-specific setup and best practices.';
-      
+      const footer =
+        '\n\n**Framework Integration:** If using React, Angular or Vue, also check the get_guidelines tool for framework-specific setup and best practices.';
+
       return createTextResponse(results.join('\n\n---\n\n') + footer);
     } catch (error) {
       return handleToolError(error, 'Error reading documentation');

--- a/test/tools/docs.test.ts
+++ b/test/tools/docs.test.ts
@@ -40,8 +40,8 @@ test('getDocTool normalizes paths', async (t) => {
 });
 
 test('getDocTool supports line ranges', async (t) => {
-  const result = await getDocTool.handler({ 
-    docs: [{ path: 'docs/09-FAQ.md', lines: '1-10' }] 
+  const result = await getDocTool.handler({
+    docs: [{ path: 'docs/09-FAQ.md', lines: '1-10' }],
   });
 
   t.is(result.content[0].type, 'text');
@@ -49,11 +49,8 @@ test('getDocTool supports line ranges', async (t) => {
 });
 
 test('getDocTool supports multiple documents', async (t) => {
-  const result = await getDocTool.handler({ 
-    docs: [
-      { path: 'docs/09-FAQ.md' },
-      { path: 'docs/08-Releases.md' }
-    ] 
+  const result = await getDocTool.handler({
+    docs: [{ path: 'docs/09-FAQ.md' }, { path: 'docs/08-Releases.md' }],
   });
 
   t.is(result.content[0].type, 'text');
@@ -61,3 +58,20 @@ test('getDocTool supports multiple documents', async (t) => {
   t.true(result.content[0].text.includes('docs/08-Releases.md'));
 });
 
+test('getDocTool blocks path traversal with ../', async (t) => {
+  const result = await getDocTool.handler({ docs: [{ path: '../../etc/passwd' }] });
+
+  t.true(result.content[0].text.includes('Access denied'));
+});
+
+test('getDocTool blocks path traversal to source code', async (t) => {
+  const result = await getDocTool.handler({ docs: [{ path: '../src/index.ts' }] });
+
+  t.true(result.content[0].text.includes('Access denied'));
+});
+
+test('getDocTool blocks path traversal with docs/ prefix', async (t) => {
+  const result = await getDocTool.handler({ docs: [{ path: 'docs/../../../etc/passwd' }] });
+
+  t.true(result.content[0].text.includes('Access denied'));
+});

--- a/test/tools/get_component_api.test.ts
+++ b/test/tools/get_component_api.test.ts
@@ -41,3 +41,43 @@ test('returns not found for invalid component', async (t) => {
 
   t.true(result.content[0].text.includes('not found'));
 });
+
+test('blocks version with path traversal', async (t) => {
+  const result = await getComponentApiTool.handler({
+    componentName: 'Button',
+    version: '../../express',
+  });
+
+  t.true(result.content[0].text.includes('Access denied'));
+});
+
+test('blocks version with slashes', async (t) => {
+  const result = await getComponentApiTool.handler({
+    componentName: 'Button',
+    version: 'latest/../../lodash',
+  });
+
+  t.true(result.content[0].text.includes('Access denied'));
+});
+
+test('allows valid semver version', async (t) => {
+  global.fetch = async () => ({ ok: false, status: 404 }) as Response;
+
+  const result = await getComponentApiTool.handler({
+    componentName: 'Button',
+    version: '2.6.0',
+  });
+
+  t.false(result.content[0].text.includes('Access denied'));
+});
+
+test('allows valid prerelease version', async (t) => {
+  global.fetch = async () => ({ ok: false, status: 404 }) as Response;
+
+  const result = await getComponentApiTool.handler({
+    componentName: 'Button',
+    version: '2.0.0-rc.1',
+  });
+
+  t.false(result.content[0].text.includes('Access denied'));
+});


### PR DESCRIPTION
## Summary
- Fix path traversal issue in `get_doc` tool that allowed reading arbitrary files outside the `docs/` directory
- Fix version parameter validation issue in `get_component_api` tool that allowed querying arbitrary npm packages via URL traversal
- Add tests for both fixes
## Details
### get_doc - Path traversal
`get_doc` joined user-supplied paths with `DOCS_DIR` without checking the resolved path stayed within the docs directory. A path like `../../etc/passwd` could read any file on the host.

**Fix:** Resolve the path and verify it starts with `DOCS_DIR` before reading.

### get_component_api - Version injection
The `version` parameter was interpolated directly into the npm registry URL. A version like `../../express` resolved to `https://registry.npmjs.org/express`, skipping the hardcoded package allowlist.

**Fix:** Validate the version string against `[\da-zA-Z.\-]+`, rejecting anything with slashes or other unexpected characters.