### PR TITLE
fix(package): include docs folder in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "build/**",
+    "docs/**",
     "LICENSE",
     "LICENSES/**",
     "npm-shrinkwrap.json",


### PR DESCRIPTION
## Summary
- Add `docs/**` to the `files` array in package.json
- Fixes `get_doc` tool not working when installed via npm (docs folder was missing)
- Docs folder is ~548KB, acceptable size increase