### PR TITLE
feat(upstreams): mount upstream MCP servers as namespaced child processes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ docs/*
 !docs/.gitkeep
 AGENTS.md
 .tsimp/
+
+# A/B harness output (results, generated reports, scaffolds, browser caches).
+# The harness scripts under scripts/ab-* write everything below .ab/.
+.ab/

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
+        "@ui5/webcomponents-react-mcp": "^2.22.2",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -843,9 +844,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1572,6 +1573,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ui5/webcomponents-react-mcp": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-react-mcp/-/webcomponents-react-mcp-2.22.2.tgz",
+      "integrity": "sha512-IV9GYvBBJrA67y3l1OqoVKXkIQFcU0YH81JvzL1bxV7LX0f+QgKpzWKVK7pm9k68+53iLRfWl9ftFdWlR1rqew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "zod": "4.4.3"
+      },
+      "bin": {
+        "ui5-wcr-mcp": "dist/index.js"
+      }
+    },
+    "node_modules/@ui5/webcomponents-react-mcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@vercel/nft": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
+    "@ui5/webcomponents-react-mcp": "^2.22.2",
     "zod": "^3.25.76"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,62 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import * as tools from "./tools/index.js";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-const server = new McpServer({
-  name: "ui5-webcomponents",
-  version: "0.0.1",
-});
+import * as tools from './tools/index.js';
+import { markShutdown, mountUpstreams, UpstreamHandle } from './upstreams/index.js';
 
-// Register tools
+const server = new McpServer(
+  {
+    name: 'ui5-webcomponents',
+    version: '0.0.1',
+  },
+  {
+    // Declared unconditionally: any combination of native + mounted upstream items can fill
+    // these. An empty list/read response is fine when nothing is registered for a slot.
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+  }
+);
+
+// Register native tools (Zod-shape inputs).
 Object.values(tools).forEach(tool => {
   server.tool(tool.name, tool.description, tool.inputSchema, tool.handler);
 });
 
-async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("UI5 Web Components MCP Server running on stdio");
+let handles: UpstreamHandle[] = [];
+
+function shutdown(): void {
+  markShutdown();
+  for (const h of handles) {
+    try {
+      h.transport.close();
+    } catch {
+      /* best-effort during shutdown */
+    }
+  }
 }
 
-main().catch((error) => {
-  console.error("Fatal error in main():", error);
+process.on('SIGINT', () => {
+  shutdown();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  shutdown();
+  process.exit(0);
+});
+process.on('exit', shutdown);
+
+async function main(): Promise<void> {
+  // Spawn and mount upstream framework MCPs (React today; Angular/Vue future). Any failure here
+  // is fatal — better the user sees a clear error than a half-mounted server.
+  handles = await mountUpstreams(server);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('UI5 Web Components MCP Server running on stdio');
+}
+
+main().catch(error => {
+  console.error('Fatal error in main():', error);
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,11 @@ process.on('SIGTERM', () => {
   shutdown();
   process.exit(0);
 });
-process.on('exit', shutdown);
+// We deliberately do NOT register a 'exit' handler: 'exit' runs synchronously and ignores
+// returned promises, so transport.close() couldn't reliably finish IPC teardown there. For
+// stdio child processes the parent's exit closes their stdin and they receive SIGPIPE on
+// the next write — that is sufficient cleanup. SIGINT/SIGTERM cover ctrl-C and supervised
+// teardown explicitly.
 
 async function main(): Promise<void> {
   // Spawn and mount upstream framework MCPs (React today; Angular/Vue future). Any failure here

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,12 +50,12 @@ process.on('SIGTERM', () => {
 // We deliberately do NOT register a 'exit' handler: 'exit' runs synchronously and ignores
 // returned promises, so transport.close() couldn't reliably finish IPC teardown there. For
 // stdio child processes the parent's exit closes their stdin and they receive SIGPIPE on
-// the next write — that is sufficient cleanup. SIGINT/SIGTERM cover ctrl-C and supervised
+// the next write - that is sufficient cleanup. SIGINT/SIGTERM cover ctrl-C and supervised
 // teardown explicitly.
 
 async function main(): Promise<void> {
   // Spawn and mount upstream framework MCPs (React today; Angular/Vue future). Any failure here
-  // is fatal — better the user sees a clear error than a half-mounted server.
+  // is fatal - better the user sees a clear error than a half-mounted server.
   handles = await mountUpstreams(server);
 
   const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,9 @@ Object.values(tools).forEach((tool) => {
   server.tool(tool.name, tool.description, tool.inputSchema, tool.handler);
 });
 
-let handles: UpstreamHandle[] = [];
+// Populated incrementally by mountUpstreams' onHandle callback (below) so signal handlers can
+// see every child that made it past connect, even mid-startup. Never reassigned.
+const handles: UpstreamHandle[] = [];
 
 function shutdown(): void {
   // Order matters: mark shutdown BEFORE closing transports. transport.close() can fire onclose
@@ -72,7 +74,13 @@ process.on('SIGTERM', () => {
 async function main(): Promise<void> {
   // Spawn and mount upstream framework MCPs (React today; Angular/Vue future). Any failure here
   // is fatal - better the user sees a clear error than a half-mounted server.
-  handles = await mountUpstreams(server);
+  //
+  // The onHandle callback pushes each handle to the module-level `handles` array as soon as
+  // its child is connected. This exposes every spawned child to the signal handlers even
+  // during the mount window - without it, a SIGINT arriving before mountUpstreams resolves
+  // would find `handles === []` and orphan the in-flight child. We don't reassign `handles`
+  // after mountUpstreams resolves: the callback is the single source of truth for what's live.
+  await mountUpstreams(server, undefined, (h) => handles.push(h));
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,31 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'node:module';
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import * as tools from './tools/index.js';
 import { markShutdown, mountUpstreams, UpstreamHandle } from './upstreams/index.js';
 
+// Read this package's version at startup so the identity advertised to MCP clients tracks
+// package.json instead of drifting (see upstreams/mount.ts for the same pattern applied to the
+// upstream-client identity). Safe '0.0.0' fallback if the lookup fails for any reason.
+const OWN_VERSION = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    // Compiled artifact lives at build/index.js, so package.json is one level up.
+    const pkg = require('../package.json') as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();
+
 const server = new McpServer(
   {
     name: 'ui5-webcomponents',
-    version: '0.0.1',
+    version: OWN_VERSION,
   },
   {
     // Declared unconditionally: any combination of native + mounted upstream items can fill

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,13 +19,16 @@ const server = new McpServer(
 );
 
 // Register native tools (Zod-shape inputs).
-Object.values(tools).forEach(tool => {
+Object.values(tools).forEach((tool) => {
   server.tool(tool.name, tool.description, tool.inputSchema, tool.handler);
 });
 
 let handles: UpstreamHandle[] = [];
 
 function shutdown(): void {
+  // Order matters: mark shutdown BEFORE closing transports. transport.close() can fire onclose
+  // synchronously in the same tick, which would otherwise trip the upstream's fail-fast handler
+  // and call process.exit(1) on a planned exit. Don't reorder.
   markShutdown();
   for (const h of handles) {
     try {
@@ -56,7 +59,7 @@ async function main(): Promise<void> {
   console.error('UI5 Web Components MCP Server running on stdio');
 }
 
-main().catch(error => {
+main().catch((error) => {
   console.error('Fatal error in main():', error);
   process.exit(1);
 });

--- a/src/upstreams/index.ts
+++ b/src/upstreams/index.ts
@@ -1,0 +1,4 @@
+export { mountUpstream, mountUpstreams, markShutdown } from './mount.js';
+export type { MountOptions, UpstreamHandle } from './mount.js';
+export { UPSTREAMS } from './registry.js';
+export type { UpstreamSpec } from './registry.js';

--- a/src/upstreams/index.ts
+++ b/src/upstreams/index.ts
@@ -1,4 +1,6 @@
 export { mountUpstream, mountUpstreams, markShutdown } from './mount.js';
+/** Test-only re-export of the module-state reset helper; production callers should not use it. */
+export { _resetForTesting } from './mount.js';
 export type { MountOptions, UpstreamHandle } from './mount.js';
 export { UPSTREAMS } from './registry.js';
 export type { UpstreamSpec } from './registry.js';

--- a/src/upstreams/mount.ts
+++ b/src/upstreams/mount.ts
@@ -1,0 +1,362 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { z, ZodTypeAny } from 'zod';
+
+import { logger } from '../logger.js';
+import { UPSTREAMS, UpstreamSpec } from './registry.js';
+
+/**
+ * One mounted upstream — the live Client/Transport pair plus what we registered from it.
+ * Returned to the entrypoint so it can close transports on shutdown.
+ */
+export interface UpstreamHandle {
+    spec: UpstreamSpec;
+    client: Client;
+    transport: StdioClientTransport;
+    toolNames: string[];
+    resourceUris: string[];
+    promptNames: string[];
+}
+
+/** Module-scoped state used by the mount layer. */
+const resourceOwners = new Map<string, UpstreamSpec>();
+let shuttingDown = false;
+
+/** Called from the entrypoint's shutdown handler before closing transports. */
+export function markShutdown(): void {
+    shuttingDown = true;
+}
+
+/** Test-only: reset module state so successive `mountUpstream` calls in tests are independent. */
+export function _resetForTesting(): void {
+    resourceOwners.clear();
+    shuttingDown = false;
+}
+
+/**
+ * Spawn each registered upstream MCP server, list its tools/resources/prompts, and re-publish
+ * them on `server` under namespaced names (resources keep their original URI; collisions throw).
+ *
+ * Throws on any failure — the caller is expected to log and exit non-zero.
+ */
+export async function mountUpstreams(server: McpServer): Promise<UpstreamHandle[]> {
+    const handles: UpstreamHandle[] = [];
+    for (const spec of UPSTREAMS) {
+        handles.push(await mountUpstream(server, spec));
+    }
+    return handles;
+}
+
+/** Options accepted by mountUpstream — used by tests to override defaults. */
+export interface MountOptions {
+    /** Override bin resolution. Used by tests pointing at a fixture script. */
+    binPath?: string;
+    /**
+     * Called when the upstream's transport closes or errors after mount. Defaults to a fail-fast
+     * handler that calls `process.exit(1)`. Tests pass a no-op so the test process survives.
+     */
+    onUpstreamExit?: (spec: UpstreamSpec, reason: 'close' | Error) => void;
+}
+
+const defaultOnUpstreamExit = (spec: UpstreamSpec, reason: 'close' | Error): void => {
+    if (shuttingDown) return;
+    if (reason === 'close') {
+        console.error(`[${spec.label}] upstream exited unexpectedly`);
+    } else {
+        console.error(`[${spec.label}] upstream error: ${stringifyError(reason)}`);
+    }
+    process.exit(1);
+};
+
+export async function mountUpstream(
+    server: McpServer,
+    spec: UpstreamSpec,
+    options: MountOptions = {}
+): Promise<UpstreamHandle> {
+    const binPath = options.binPath ?? resolveUpstreamBin(spec);
+    const onExit = options.onUpstreamExit ?? defaultOnUpstreamExit;
+    logger.debug(`[${spec.label}] spawning ${binPath}`);
+
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [binPath],
+        stderr: 'pipe',
+    });
+
+    const client = new Client(
+        { name: 'ui5-webcomponents-mcp-server', version: '0.0.0' },
+        { capabilities: {} }
+    );
+
+    try {
+        await client.connect(transport);
+    } catch (error) {
+        throw new Error(`[${spec.label}] failed to connect: ${stringifyError(error)}`);
+    }
+
+    // Pipe child stderr through the debug logger so it's visible when DEBUG=1 but quiet otherwise.
+    if (transport.stderr) {
+        transport.stderr.on('data', chunk => {
+            const text = String(chunk).replace(/\n+$/, '');
+            for (const line of text.split('\n')) {
+                logger.debug(`[${spec.label}] ${line}`);
+            }
+        });
+    }
+
+    // Runtime fail-fast hook — overridable for tests.
+    transport.onclose = () => onExit(spec, 'close');
+    transport.onerror = err => onExit(spec, err);
+
+    try {
+        return await registerUpstream(server, spec, client, transport);
+    } catch (error) {
+        // Anything failing past connect (URI collision, listTools error, registration error)
+        // leaves the child process running. Tear it down before propagating so the caller's
+        // process doesn't leak children.
+        try {
+            await transport.close();
+        } catch {
+            /* best-effort */
+        }
+        throw error;
+    }
+}
+
+async function registerUpstream(
+    server: McpServer,
+    spec: UpstreamSpec,
+    client: Client,
+    transport: StdioClientTransport
+): Promise<UpstreamHandle> {
+    // We only call list* for capabilities the upstream advertises — calling tools/list against
+    // a server without `tools` capability would return -32601 Method not found.
+    const upstreamCaps = client.getServerCapabilities() ?? {};
+
+    const toolNames: string[] = [];
+    const resourceUris: string[] = [];
+    const promptNames: string[] = [];
+
+    if (upstreamCaps.tools) {
+        const { tools } = await client.listTools();
+        for (const tool of tools) {
+            const mountedName = `${spec.prefix}_${tool.name}`;
+            const inputShape = jsonObjectSchemaToZodShape(tool.inputSchema);
+            const config: {
+                description?: string;
+                annotations?: typeof tool.annotations;
+                inputSchema?: Record<string, ZodTypeAny>;
+            } = {
+                description: tool.description,
+                annotations: tool.annotations,
+            };
+            if (inputShape) config.inputSchema = inputShape;
+            // Handler signature differs based on whether inputSchema is set; cast through `unknown`
+            // since the upstream server is the actual validator.
+            server.registerTool(
+                mountedName,
+                config as Parameters<McpServer['registerTool']>[1],
+                (async (args: Record<string, unknown>) => {
+                    return await client.callTool({
+                        name: tool.name,
+                        arguments: args ?? {},
+                    });
+                }) as unknown as Parameters<McpServer['registerTool']>[2]
+            );
+            toolNames.push(mountedName);
+        }
+    }
+
+    if (upstreamCaps.resources) {
+        const { resources } = await client.listResources();
+        for (const resource of resources) {
+            const owner = resourceOwners.get(resource.uri);
+            if (owner) {
+                throw new Error(
+                    `Resource URI collision: "${resource.uri}" is provided by both "${owner.prefix}" and "${spec.prefix}". Resource URIs must be unique across all mounted upstreams.`
+                );
+            }
+            resourceOwners.set(resource.uri, spec);
+            server.registerResource(
+                resource.name,
+                resource.uri,
+                {
+                    description: resource.description,
+                    mimeType: resource.mimeType,
+                    title: resource.title,
+                },
+                async uri => {
+                    const result = await client.readResource({ uri: uri.toString() });
+                    return result;
+                }
+            );
+            resourceUris.push(resource.uri);
+        }
+    }
+
+    if (upstreamCaps.prompts) {
+        const { prompts } = await client.listPrompts();
+        for (const prompt of prompts) {
+            const mountedName = `${spec.prefix}_${prompt.name}`;
+            const argsShape = promptArgsToZodShape(prompt.arguments);
+            const config: { description?: string; argsSchema?: Record<string, ZodTypeAny> } = {
+                description: prompt.description,
+            };
+            if (argsShape) config.argsSchema = argsShape;
+            server.registerPrompt(
+                mountedName,
+                config as Parameters<McpServer['registerPrompt']>[1],
+                (async (args: Record<string, unknown>) => {
+                    return await client.getPrompt({
+                        name: prompt.name,
+                        arguments: args as Record<string, string> | undefined,
+                    });
+                }) as unknown as Parameters<McpServer['registerPrompt']>[2]
+            );
+            promptNames.push(mountedName);
+        }
+    }
+
+    logger.debug(
+        `[${spec.label}] mounted ${toolNames.length} tools, ${resourceUris.length} resources, ${promptNames.length} prompts`
+    );
+
+    return { spec, client, transport, toolNames, resourceUris, promptNames };
+}
+
+/**
+ * Resolve the absolute path to an upstream package's MCP-server bin, by reading its package.json
+ * `bin` field. Supports both string and `{ name: path }` forms; if multiple bins exist, picks the
+ * first (upstream MCP packages have just one in practice).
+ */
+function resolveUpstreamBin(spec: UpstreamSpec): string {
+    const require = createRequire(import.meta.url);
+    let pkgJsonPath: string;
+    try {
+        pkgJsonPath = require.resolve(`${spec.packageName}/package.json`);
+    } catch (error) {
+        throw new Error(
+            `[${spec.label}] cannot resolve package "${spec.packageName}" — is it installed? (${stringifyError(error)})`
+        );
+    }
+
+    const pkg = require(pkgJsonPath) as { bin?: string | Record<string, string> };
+    const binField = pkg.bin;
+    let binRel: string | undefined;
+    if (typeof binField === 'string') {
+        binRel = binField;
+    } else if (binField && typeof binField === 'object') {
+        binRel = Object.values(binField)[0];
+    }
+    if (!binRel) {
+        throw new Error(
+            `[${spec.label}] package "${spec.packageName}" has no "bin" field in package.json`
+        );
+    }
+    return path.resolve(path.dirname(pkgJsonPath), binRel);
+}
+
+/**
+ * Convert an MCP tool's JSON Schema (always `type: object` per spec) into the raw-shape form
+ * (Record<string, ZodTypeAny>) that `McpServer.registerTool` expects. Returns undefined if the
+ * schema has no properties — `registerTool` is fine omitting `inputSchema` in that case.
+ *
+ * This is intentionally limited to the JSON Schema constructs MCP tool inputs actually use in
+ * practice: primitive types (string/number/integer/boolean), enum, default, description, and
+ * required. Nested objects and combinators (oneOf/anyOf/allOf) fall back to z.any() — the
+ * upstream still validates the call, so this is safe.
+ */
+function jsonObjectSchemaToZodShape(
+    schema: unknown
+): Record<string, ZodTypeAny> | undefined {
+    if (!schema || typeof schema !== 'object') return undefined;
+    const s = schema as {
+        type?: string;
+        properties?: Record<string, unknown>;
+        required?: string[];
+    };
+    if (s.type !== 'object' || !s.properties) return undefined;
+
+    const required = new Set(s.required ?? []);
+    const shape: Record<string, ZodTypeAny> = {};
+    for (const [key, propSchema] of Object.entries(s.properties)) {
+        let z3 = jsonValueSchemaToZod(propSchema);
+        if (!required.has(key)) z3 = z3.optional();
+        shape[key] = z3;
+    }
+    return Object.keys(shape).length > 0 ? shape : undefined;
+}
+
+function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
+    if (!schema || typeof schema !== 'object') return z.any();
+    const s = schema as {
+        type?: string;
+        enum?: unknown[];
+        description?: string;
+        default?: unknown;
+        items?: unknown;
+    };
+
+    let zodSchema: ZodTypeAny;
+
+    if (Array.isArray(s.enum) && s.enum.length > 0) {
+        // Zod's z.enum requires string literals; values may be numbers etc., so use z.union of
+        // literals when there are 2+, or the single literal directly. Cast through unknown so
+        // TS accepts the dynamically-built tuple at z.union's required-2-tuple signature.
+        const literals = s.enum.map(v => z.literal(v as string | number | boolean));
+        zodSchema =
+            literals.length === 1
+                ? literals[0]
+                : z.union(literals as unknown as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
+    } else {
+        switch (s.type) {
+            case 'string':
+                zodSchema = z.string();
+                break;
+            case 'number':
+            case 'integer':
+                zodSchema = z.number();
+                break;
+            case 'boolean':
+                zodSchema = z.boolean();
+                break;
+            case 'array':
+                zodSchema = z.array(s.items ? jsonValueSchemaToZod(s.items) : z.any());
+                break;
+            default:
+                // Object subschemas, oneOf/anyOf, etc. — pass through; upstream re-validates.
+                zodSchema = z.any();
+        }
+    }
+
+    if (s.description) zodSchema = zodSchema.describe(s.description);
+    if (s.default !== undefined) zodSchema = zodSchema.default(s.default as never);
+    return zodSchema;
+}
+
+/**
+ * Convert MCP prompt arguments (a flat array of `{ name, description?, required? }`) to the
+ * raw-shape form expected by `registerPrompt`. Each argument is a string; required arguments
+ * are required, others are optional.
+ */
+function promptArgsToZodShape(
+    args: Array<{ name: string; description?: string; required?: boolean }> | undefined
+): Record<string, ZodTypeAny> | undefined {
+    if (!args || args.length === 0) return undefined;
+    const shape: Record<string, ZodTypeAny> = {};
+    for (const arg of args) {
+        let z3: ZodTypeAny = z.string();
+        if (arg.description) z3 = z3.describe(arg.description);
+        if (!arg.required) z3 = z3.optional();
+        shape[arg.name] = z3;
+    }
+    return shape;
+}
+
+function stringifyError(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    return String(error);
+}

--- a/src/upstreams/mount.ts
+++ b/src/upstreams/mount.ts
@@ -13,12 +13,12 @@ import { UPSTREAMS, UpstreamSpec } from './registry.js';
  * Returned to the entrypoint so it can close transports on shutdown.
  */
 export interface UpstreamHandle {
-    spec: UpstreamSpec;
-    client: Client;
-    transport: StdioClientTransport;
-    toolNames: string[];
-    resourceUris: string[];
-    promptNames: string[];
+  spec: UpstreamSpec;
+  client: Client;
+  transport: StdioClientTransport;
+  toolNames: string[];
+  resourceUris: string[];
+  promptNames: string[];
 }
 
 /** Module-scoped state used by the mount layer. */
@@ -27,13 +27,18 @@ let shuttingDown = false;
 
 /** Called from the entrypoint's shutdown handler before closing transports. */
 export function markShutdown(): void {
-    shuttingDown = true;
+  shuttingDown = true;
 }
 
-/** Test-only: reset module state so successive `mountUpstream` calls in tests are independent. */
+/**
+ * Test-only: reset module state so successive `mountUpstream` calls in tests are independent.
+ *
+ * Callers must also construct a fresh `McpServer` for each mount — this only resets the
+ * module-scoped registry/flags, not anything already registered on a server instance.
+ */
 export function _resetForTesting(): void {
-    resourceOwners.clear();
-    shuttingDown = false;
+  resourceOwners.clear();
+  shuttingDown = false;
 }
 
 /**
@@ -43,220 +48,241 @@ export function _resetForTesting(): void {
  * Throws on any failure — the caller is expected to log and exit non-zero.
  */
 export async function mountUpstreams(server: McpServer): Promise<UpstreamHandle[]> {
-    const handles: UpstreamHandle[] = [];
-    for (const spec of UPSTREAMS) {
-        handles.push(await mountUpstream(server, spec));
+  // Cheap insurance against typos in the registry: two upstreams sharing a prefix would silently
+  // collide on every same-named tool/prompt and behave non-deterministically. Detect at startup.
+  const seenPrefixes = new Set<string>();
+  for (const spec of UPSTREAMS) {
+    if (seenPrefixes.has(spec.prefix)) {
+      throw new Error(
+        `Duplicate upstream prefix "${spec.prefix}" in registry — prefixes must be unique.`
+      );
     }
-    return handles;
+    seenPrefixes.add(spec.prefix);
+  }
+
+  const handles: UpstreamHandle[] = [];
+  for (const spec of UPSTREAMS) {
+    handles.push(await mountUpstream(server, spec));
+  }
+  return handles;
 }
 
 /** Options accepted by mountUpstream — used by tests to override defaults. */
 export interface MountOptions {
-    /** Override bin resolution. Used by tests pointing at a fixture script. */
-    binPath?: string;
-    /**
-     * Called when the upstream's transport closes or errors after mount. Defaults to a fail-fast
-     * handler that calls `process.exit(1)`. Tests pass a no-op so the test process survives.
-     */
-    onUpstreamExit?: (spec: UpstreamSpec, reason: 'close' | Error) => void;
+  /** Override bin resolution. Used by tests pointing at a fixture script. */
+  binPath?: string;
+  /**
+   * Called when the upstream's transport closes or errors after mount. Defaults to a fail-fast
+   * handler that calls `process.exit(1)`. Tests pass a no-op so the test process survives.
+   */
+  onUpstreamExit?: (spec: UpstreamSpec, reason: 'close' | Error) => void;
 }
 
 const defaultOnUpstreamExit = (spec: UpstreamSpec, reason: 'close' | Error): void => {
-    if (shuttingDown) return;
-    if (reason === 'close') {
-        console.error(`[${spec.label}] upstream exited unexpectedly`);
-    } else {
-        console.error(`[${spec.label}] upstream error: ${stringifyError(reason)}`);
-    }
-    process.exit(1);
+  if (shuttingDown) return;
+  if (reason === 'close') {
+    console.error(`[${spec.label}] upstream exited unexpectedly`);
+  } else {
+    console.error(`[${spec.label}] upstream error: ${stringifyError(reason)}`);
+  }
+  process.exit(1);
 };
 
 export async function mountUpstream(
-    server: McpServer,
-    spec: UpstreamSpec,
-    options: MountOptions = {}
+  server: McpServer,
+  spec: UpstreamSpec,
+  options: MountOptions = {}
 ): Promise<UpstreamHandle> {
-    const binPath = options.binPath ?? resolveUpstreamBin(spec);
-    const onExit = options.onUpstreamExit ?? defaultOnUpstreamExit;
-    logger.debug(`[${spec.label}] spawning ${binPath}`);
+  const binPath = options.binPath ?? resolveUpstreamBin(spec);
+  const onExit = options.onUpstreamExit ?? defaultOnUpstreamExit;
+  logger.debug(`[${spec.label}] spawning ${binPath}`);
 
-    const transport = new StdioClientTransport({
-        command: process.execPath,
-        args: [binPath],
-        stderr: 'pipe',
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [binPath],
+    stderr: 'pipe',
+  });
+
+  const client = new Client(
+    { name: 'ui5-webcomponents-mcp-server', version: '0.0.0' },
+    { capabilities: {} }
+  );
+
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    throw new Error(`[${spec.label}] failed to connect: ${stringifyError(error)}`);
+  }
+
+  // Pipe child stderr through the debug logger so it's visible when DEBUG=1 but quiet otherwise.
+  if (transport.stderr) {
+    transport.stderr.on('data', (chunk) => {
+      const text = String(chunk).replace(/\n+$/, '');
+      for (const line of text.split('\n')) {
+        logger.debug(`[${spec.label}] ${line}`);
+      }
     });
+  }
 
-    const client = new Client(
-        { name: 'ui5-webcomponents-mcp-server', version: '0.0.0' },
-        { capabilities: {} }
-    );
+  // Runtime fail-fast hook — overridable for tests.
+  transport.onclose = () => onExit(spec, 'close');
+  transport.onerror = (err) => onExit(spec, err);
 
+  try {
+    return await registerUpstream(server, spec, client, transport);
+  } catch (error) {
+    // Anything failing past connect (URI collision, listTools error, registration error)
+    // leaves the child process running. Tear it down before propagating so the caller's
+    // process doesn't leak children.
     try {
-        await client.connect(transport);
-    } catch (error) {
-        throw new Error(`[${spec.label}] failed to connect: ${stringifyError(error)}`);
+      await transport.close();
+    } catch {
+      /* best-effort */
     }
-
-    // Pipe child stderr through the debug logger so it's visible when DEBUG=1 but quiet otherwise.
-    if (transport.stderr) {
-        transport.stderr.on('data', chunk => {
-            const text = String(chunk).replace(/\n+$/, '');
-            for (const line of text.split('\n')) {
-                logger.debug(`[${spec.label}] ${line}`);
-            }
-        });
-    }
-
-    // Runtime fail-fast hook — overridable for tests.
-    transport.onclose = () => onExit(spec, 'close');
-    transport.onerror = err => onExit(spec, err);
-
-    try {
-        return await registerUpstream(server, spec, client, transport);
-    } catch (error) {
-        // Anything failing past connect (URI collision, listTools error, registration error)
-        // leaves the child process running. Tear it down before propagating so the caller's
-        // process doesn't leak children.
-        try {
-            await transport.close();
-        } catch {
-            /* best-effort */
-        }
-        throw error;
-    }
+    throw error;
+  }
 }
 
 async function registerUpstream(
-    server: McpServer,
-    spec: UpstreamSpec,
-    client: Client,
-    transport: StdioClientTransport
+  server: McpServer,
+  spec: UpstreamSpec,
+  client: Client,
+  transport: StdioClientTransport
 ): Promise<UpstreamHandle> {
-    // We only call list* for capabilities the upstream advertises — calling tools/list against
-    // a server without `tools` capability would return -32601 Method not found.
-    const upstreamCaps = client.getServerCapabilities() ?? {};
+  // We only call list* for capabilities the upstream advertises — calling tools/list against
+  // a server without `tools` capability would return -32601 Method not found.
+  const upstreamCaps = client.getServerCapabilities() ?? {};
 
-    const toolNames: string[] = [];
-    const resourceUris: string[] = [];
-    const promptNames: string[] = [];
+  const toolNames: string[] = [];
+  const resourceUris: string[] = [];
+  const promptNames: string[] = [];
 
-    if (upstreamCaps.tools) {
-        const { tools } = await client.listTools();
-        for (const tool of tools) {
-            const mountedName = `${spec.prefix}_${tool.name}`;
-            const inputShape = jsonObjectSchemaToZodShape(tool.inputSchema);
-            const config: {
-                description?: string;
-                annotations?: typeof tool.annotations;
-                inputSchema?: Record<string, ZodTypeAny>;
-            } = {
-                description: tool.description,
-                annotations: tool.annotations,
-            };
-            if (inputShape) config.inputSchema = inputShape;
-            // Handler signature differs based on whether inputSchema is set; cast through `unknown`
-            // since the upstream server is the actual validator.
-            server.registerTool(
-                mountedName,
-                config as Parameters<McpServer['registerTool']>[1],
-                (async (args: Record<string, unknown>) => {
-                    return await client.callTool({
-                        name: tool.name,
-                        arguments: args ?? {},
-                    });
-                }) as unknown as Parameters<McpServer['registerTool']>[2]
-            );
-            toolNames.push(mountedName);
-        }
+  if (upstreamCaps.tools) {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      const mountedName = `${spec.prefix}_${tool.name}`;
+      const inputShape = jsonObjectSchemaToZodShape(tool.inputSchema);
+      const config: {
+        description?: string;
+        annotations?: typeof tool.annotations;
+        inputSchema?: Record<string, ZodTypeAny>;
+      } = {
+        description: tool.description,
+        annotations: tool.annotations,
+      };
+      if (inputShape) config.inputSchema = inputShape;
+      // Handler signature differs based on whether inputSchema is set; cast through `unknown`
+      // since the upstream server is the actual validator.
+      server.registerTool(
+        mountedName,
+        config as Parameters<McpServer['registerTool']>[1],
+        (async (args: Record<string, unknown>) => {
+          return await client.callTool({
+            name: tool.name,
+            arguments: args ?? {},
+          });
+        }) as unknown as Parameters<McpServer['registerTool']>[2]
+      );
+      toolNames.push(mountedName);
     }
+  }
 
-    if (upstreamCaps.resources) {
-        const { resources } = await client.listResources();
-        for (const resource of resources) {
-            const owner = resourceOwners.get(resource.uri);
-            if (owner) {
-                throw new Error(
-                    `Resource URI collision: "${resource.uri}" is provided by both "${owner.prefix}" and "${spec.prefix}". Resource URIs must be unique across all mounted upstreams.`
-                );
-            }
-            resourceOwners.set(resource.uri, spec);
-            server.registerResource(
-                resource.name,
-                resource.uri,
-                {
-                    description: resource.description,
-                    mimeType: resource.mimeType,
-                    title: resource.title,
-                },
-                async uri => {
-                    const result = await client.readResource({ uri: uri.toString() });
-                    return result;
-                }
-            );
-            resourceUris.push(resource.uri);
+  if (upstreamCaps.resources) {
+    const { resources } = await client.listResources();
+    for (const resource of resources) {
+      const owner = resourceOwners.get(resource.uri);
+      if (owner) {
+        throw new Error(
+          `Resource URI collision: "${resource.uri}" is provided by both "${owner.prefix}" and "${spec.prefix}". Resource URIs must be unique across all mounted upstreams.`
+        );
+      }
+      resourceOwners.set(resource.uri, spec);
+      server.registerResource(
+        resource.name,
+        resource.uri,
+        {
+          description: resource.description,
+          mimeType: resource.mimeType,
+          title: resource.title,
+        },
+        async (uri) => {
+          // Forward verbatim — the upstream is the source of truth for the
+          // ReadResourceResult shape (`{ contents: [...] }`); if it's
+          // schema-violating the parent's framework will throw at response time,
+          // matching the same trust model as tool/prompt forwarding.
+          const result = await client.readResource({ uri: uri.toString() });
+          return result;
         }
+      );
+      resourceUris.push(resource.uri);
     }
+  }
 
-    if (upstreamCaps.prompts) {
-        const { prompts } = await client.listPrompts();
-        for (const prompt of prompts) {
-            const mountedName = `${spec.prefix}_${prompt.name}`;
-            const argsShape = promptArgsToZodShape(prompt.arguments);
-            const config: { description?: string; argsSchema?: Record<string, ZodTypeAny> } = {
-                description: prompt.description,
-            };
-            if (argsShape) config.argsSchema = argsShape;
-            server.registerPrompt(
-                mountedName,
-                config as Parameters<McpServer['registerPrompt']>[1],
-                (async (args: Record<string, unknown>) => {
-                    return await client.getPrompt({
-                        name: prompt.name,
-                        arguments: args as Record<string, string> | undefined,
-                    });
-                }) as unknown as Parameters<McpServer['registerPrompt']>[2]
-            );
-            promptNames.push(mountedName);
-        }
+  if (upstreamCaps.prompts) {
+    const { prompts } = await client.listPrompts();
+    for (const prompt of prompts) {
+      const mountedName = `${spec.prefix}_${prompt.name}`;
+      const argsShape = promptArgsToZodShape(prompt.arguments);
+      const config: { description?: string; argsSchema?: Record<string, ZodTypeAny> } = {
+        description: prompt.description,
+      };
+      if (argsShape) config.argsSchema = argsShape;
+      server.registerPrompt(
+        mountedName,
+        config as Parameters<McpServer['registerPrompt']>[1],
+        (async (args: Record<string, unknown>) => {
+          return await client.getPrompt({
+            name: prompt.name,
+            arguments: args as Record<string, string> | undefined,
+          });
+        }) as unknown as Parameters<McpServer['registerPrompt']>[2]
+      );
+      promptNames.push(mountedName);
     }
+  }
 
-    logger.debug(
-        `[${spec.label}] mounted ${toolNames.length} tools, ${resourceUris.length} resources, ${promptNames.length} prompts`
-    );
+  logger.debug(
+    `[${spec.label}] mounted ${toolNames.length} tools, ${resourceUris.length} resources, ${promptNames.length} prompts`
+  );
 
-    return { spec, client, transport, toolNames, resourceUris, promptNames };
+  return { spec, client, transport, toolNames, resourceUris, promptNames };
 }
 
 /**
  * Resolve the absolute path to an upstream package's MCP-server bin, by reading its package.json
- * `bin` field. Supports both string and `{ name: path }` forms; if multiple bins exist, picks the
- * first (upstream MCP packages have just one in practice).
+ * `bin` field. Supports both string and `{ name: path }` forms. When `bin` is an object with
+ * multiple entries, prefers the one whose key matches the package's basename (e.g. `react-mcp`
+ * for `@ui5/webcomponents-react-mcp`); otherwise picks the first entry deterministically by
+ * iteration order. Throws if no bin can be resolved.
  */
 function resolveUpstreamBin(spec: UpstreamSpec): string {
-    const require = createRequire(import.meta.url);
-    let pkgJsonPath: string;
-    try {
-        pkgJsonPath = require.resolve(`${spec.packageName}/package.json`);
-    } catch (error) {
-        throw new Error(
-            `[${spec.label}] cannot resolve package "${spec.packageName}" — is it installed? (${stringifyError(error)})`
-        );
-    }
+  const require = createRequire(import.meta.url);
+  let pkgJsonPath: string;
+  try {
+    pkgJsonPath = require.resolve(`${spec.packageName}/package.json`);
+  } catch (error) {
+    throw new Error(
+      `[${spec.label}] cannot resolve package "${spec.packageName}" — is it installed? (${stringifyError(error)})`
+    );
+  }
 
-    const pkg = require(pkgJsonPath) as { bin?: string | Record<string, string> };
-    const binField = pkg.bin;
-    let binRel: string | undefined;
-    if (typeof binField === 'string') {
-        binRel = binField;
-    } else if (binField && typeof binField === 'object') {
-        binRel = Object.values(binField)[0];
-    }
-    if (!binRel) {
-        throw new Error(
-            `[${spec.label}] package "${spec.packageName}" has no "bin" field in package.json`
-        );
-    }
-    return path.resolve(path.dirname(pkgJsonPath), binRel);
+  const pkg = require(pkgJsonPath) as { bin?: string | Record<string, string> };
+  const binField = pkg.bin;
+  let binRel: string | undefined;
+  if (typeof binField === 'string') {
+    binRel = binField;
+  } else if (binField && typeof binField === 'object') {
+    // Prefer the bin entry whose name matches the package basename — that's the convention
+    // for npm packages that ship multiple binaries (one of which is the "main" tool).
+    const basename = spec.packageName.split('/').pop() ?? spec.packageName;
+    binRel = binField[basename] ?? Object.values(binField)[0];
+  }
+  if (!binRel) {
+    throw new Error(
+      `[${spec.label}] package "${spec.packageName}" has no "bin" field in package.json`
+    );
+  }
+  return path.resolve(path.dirname(pkgJsonPath), binRel);
 }
 
 /**
@@ -269,94 +295,96 @@ function resolveUpstreamBin(spec: UpstreamSpec): string {
  * required. Nested objects and combinators (oneOf/anyOf/allOf) fall back to z.any() — the
  * upstream still validates the call, so this is safe.
  */
-function jsonObjectSchemaToZodShape(
-    schema: unknown
-): Record<string, ZodTypeAny> | undefined {
-    if (!schema || typeof schema !== 'object') return undefined;
-    const s = schema as {
-        type?: string;
-        properties?: Record<string, unknown>;
-        required?: string[];
-    };
-    if (s.type !== 'object' || !s.properties) return undefined;
+function jsonObjectSchemaToZodShape(schema: unknown): Record<string, ZodTypeAny> | undefined {
+  if (!schema || typeof schema !== 'object') return undefined;
+  const s = schema as {
+    type?: string;
+    properties?: Record<string, unknown>;
+    required?: string[];
+  };
+  if (s.type !== 'object' || !s.properties) return undefined;
 
-    const required = new Set(s.required ?? []);
-    const shape: Record<string, ZodTypeAny> = {};
-    for (const [key, propSchema] of Object.entries(s.properties)) {
-        let z3 = jsonValueSchemaToZod(propSchema);
-        if (!required.has(key)) z3 = z3.optional();
-        shape[key] = z3;
-    }
-    return Object.keys(shape).length > 0 ? shape : undefined;
+  const required = new Set(s.required ?? []);
+  const shape: Record<string, ZodTypeAny> = {};
+  for (const [key, propSchema] of Object.entries(s.properties)) {
+    let z3 = jsonValueSchemaToZod(propSchema);
+    if (!required.has(key)) z3 = z3.optional();
+    shape[key] = z3;
+  }
+  return Object.keys(shape).length > 0 ? shape : undefined;
 }
 
 function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
-    if (!schema || typeof schema !== 'object') return z.any();
-    const s = schema as {
-        type?: string;
-        enum?: unknown[];
-        description?: string;
-        default?: unknown;
-        items?: unknown;
-    };
+  if (!schema || typeof schema !== 'object') return z.any();
+  const s = schema as {
+    type?: string;
+    enum?: unknown[];
+    description?: string;
+    default?: unknown;
+    items?: unknown;
+  };
 
-    let zodSchema: ZodTypeAny;
+  let zodSchema: ZodTypeAny;
 
-    if (Array.isArray(s.enum) && s.enum.length > 0) {
-        // Zod's z.enum requires string literals; values may be numbers etc., so use z.union of
-        // literals when there are 2+, or the single literal directly. Cast through unknown so
-        // TS accepts the dynamically-built tuple at z.union's required-2-tuple signature.
-        const literals = s.enum.map(v => z.literal(v as string | number | boolean));
-        zodSchema =
-            literals.length === 1
-                ? literals[0]
-                : z.union(literals as unknown as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
-    } else {
-        switch (s.type) {
-            case 'string':
-                zodSchema = z.string();
-                break;
-            case 'number':
-            case 'integer':
-                zodSchema = z.number();
-                break;
-            case 'boolean':
-                zodSchema = z.boolean();
-                break;
-            case 'array':
-                zodSchema = z.array(s.items ? jsonValueSchemaToZod(s.items) : z.any());
-                break;
-            default:
-                // Object subschemas, oneOf/anyOf, etc. — pass through; upstream re-validates.
-                zodSchema = z.any();
-        }
+  if (Array.isArray(s.enum) && s.enum.length > 0) {
+    // Zod's z.enum requires string literals; enum values may be numbers/booleans, so we
+    // build z.literal()s and union them. z.union requires at least 2 members — for a
+    // single-value enum, return the literal directly. The double cast is needed because
+    // TS can't statically prove `literals` has 2+ elements at this point.
+    const literals = s.enum.map((v) => z.literal(v as string | number | boolean));
+    zodSchema =
+      literals.length === 1
+        ? literals[0]
+        : z.union(literals as unknown as [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]);
+  } else {
+    switch (s.type) {
+      case 'string':
+        zodSchema = z.string();
+        break;
+      case 'number':
+      case 'integer':
+        zodSchema = z.number();
+        break;
+      case 'boolean':
+        zodSchema = z.boolean();
+        break;
+      case 'array':
+        zodSchema = z.array(s.items ? jsonValueSchemaToZod(s.items) : z.any());
+        break;
+      default:
+        // Object subschemas, oneOf/anyOf, etc. — pass through; upstream re-validates.
+        zodSchema = z.any();
     }
+  }
 
-    if (s.description) zodSchema = zodSchema.describe(s.description);
-    if (s.default !== undefined) zodSchema = zodSchema.default(s.default as never);
-    return zodSchema;
+  if (s.description) zodSchema = zodSchema.describe(s.description);
+  if (s.default !== undefined) zodSchema = zodSchema.default(s.default as never);
+  return zodSchema;
 }
 
 /**
  * Convert MCP prompt arguments (a flat array of `{ name, description?, required? }`) to the
  * raw-shape form expected by `registerPrompt`. Each argument is a string; required arguments
  * are required, others are optional.
+ *
+ * Note: per the MCP spec (https://spec.modelcontextprotocol.io), prompt arguments are always
+ * strings — there is no typed-prompt-arg construct. Don't extend this to other Zod types.
  */
 function promptArgsToZodShape(
-    args: Array<{ name: string; description?: string; required?: boolean }> | undefined
+  args: Array<{ name: string; description?: string; required?: boolean }> | undefined
 ): Record<string, ZodTypeAny> | undefined {
-    if (!args || args.length === 0) return undefined;
-    const shape: Record<string, ZodTypeAny> = {};
-    for (const arg of args) {
-        let z3: ZodTypeAny = z.string();
-        if (arg.description) z3 = z3.describe(arg.description);
-        if (!arg.required) z3 = z3.optional();
-        shape[arg.name] = z3;
-    }
-    return shape;
+  if (!args || args.length === 0) return undefined;
+  const shape: Record<string, ZodTypeAny> = {};
+  for (const arg of args) {
+    let z3: ZodTypeAny = z.string();
+    if (arg.description) z3 = z3.describe(arg.description);
+    if (!arg.required) z3 = z3.optional();
+    shape[arg.name] = z3;
+  }
+  return shape;
 }
 
 function stringifyError(error: unknown): string {
-    if (error instanceof Error) return error.message;
-    return String(error);
+  if (error instanceof Error) return error.message;
+  return String(error);
 }

--- a/src/upstreams/mount.ts
+++ b/src/upstreams/mount.ts
@@ -62,14 +62,22 @@ export function _resetForTesting(): void {
  * Spawn each registered upstream MCP server, list its tools/resources/prompts, and re-publish
  * them on `server` under namespaced names (resources keep their original URI; collisions throw).
  *
- * Throws on any failure - the caller is expected to log and exit non-zero.
+ * Throws on any failure - the caller is expected to log and exit non-zero. On partial failure
+ * (some upstreams already mounted, later one throws) every already-mounted transport is closed
+ * before the error propagates, so no child process is leaked.
+ *
+ * `onHandle` is called synchronously as each mount completes, before the next one starts. The
+ * entrypoint uses this to expose each handle to its signal handlers immediately, so a SIGINT
+ * arriving mid-`mountUpstreams` can still close every child that made it past connect. Without
+ * this callback, the caller only sees handles after the whole array resolves.
  *
  * The optional `upstreams` parameter exists for tests; production callers pass nothing and the
  * module-level `UPSTREAMS` list is used.
  */
 export async function mountUpstreams(
   server: McpServer,
-  upstreams: ReadonlyArray<UpstreamSpec> = UPSTREAMS
+  upstreams: ReadonlyArray<UpstreamSpec> = UPSTREAMS,
+  onHandle?: (handle: UpstreamHandle) => void
 ): Promise<UpstreamHandle[]> {
   // Cheap insurance against typos in the registry: two upstreams sharing a prefix would silently
   // collide on every same-named tool/prompt and behave non-deterministically. Detect at startup
@@ -85,8 +93,28 @@ export async function mountUpstreams(
   }
 
   const handles: UpstreamHandle[] = [];
-  for (const spec of upstreams) {
-    handles.push(await mountUpstream(server, spec));
+  try {
+    for (const spec of upstreams) {
+      const handle = await mountUpstream(server, spec);
+      handles.push(handle);
+      onHandle?.(handle);
+    }
+  } catch (error) {
+    // A later mount threw. Every handle collected so far owns a live child - tear them down
+    // before propagating so we don't leak orphans. Detach onclose/onerror first: close() awaits
+    // the child's 'close' event which fires this transport's onclose synchronously (SDK
+    // stdio.js), and defaultOnUpstreamExit would call process.exit(1) inside the await,
+    // swallowing the original error before it reaches the caller.
+    for (const h of handles) {
+      h.transport.onclose = undefined;
+      h.transport.onerror = undefined;
+      try {
+        await h.transport.close();
+      } catch {
+        /* best-effort */
+      }
+    }
+    throw error;
   }
   return handles;
 }

--- a/src/upstreams/mount.ts
+++ b/src/upstreams/mount.ts
@@ -9,7 +9,7 @@ import { logger } from '../logger.js';
 import { UPSTREAMS, UpstreamSpec } from './registry.js';
 
 /**
- * One mounted upstream — the live Client/Transport pair plus what we registered from it.
+ * One mounted upstream - the live Client/Transport pair plus what we registered from it.
  * Returned to the entrypoint so it can close transports on shutdown.
  */
 export interface UpstreamHandle {
@@ -28,7 +28,7 @@ let shuttingDown = false;
 /**
  * Own version, read once from this package's package.json. Forwarded to upstream MCP servers as
  * the connecting client's version so their logs are useful when debugging which parent
- * connected. Falls back to '0.0.0' if the lookup fails for any reason — non-fatal.
+ * connected. Falls back to '0.0.0' if the lookup fails for any reason - non-fatal.
  */
 const OWN_VERSION = readOwnVersion();
 function readOwnVersion(): string {
@@ -50,7 +50,7 @@ export function markShutdown(): void {
 /**
  * Test-only: reset module state so successive `mountUpstream` calls in tests are independent.
  *
- * Callers must also construct a fresh `McpServer` for each mount — this only resets the
+ * Callers must also construct a fresh `McpServer` for each mount - this only resets the
  * module-scoped registry/flags, not anything already registered on a server instance.
  */
 export function _resetForTesting(): void {
@@ -62,7 +62,7 @@ export function _resetForTesting(): void {
  * Spawn each registered upstream MCP server, list its tools/resources/prompts, and re-publish
  * them on `server` under namespaced names (resources keep their original URI; collisions throw).
  *
- * Throws on any failure — the caller is expected to log and exit non-zero.
+ * Throws on any failure - the caller is expected to log and exit non-zero.
  *
  * The optional `upstreams` parameter exists for tests; production callers pass nothing and the
  * module-level `UPSTREAMS` list is used.
@@ -78,7 +78,7 @@ export async function mountUpstreams(
   for (const spec of upstreams) {
     if (seenPrefixes.has(spec.prefix)) {
       throw new Error(
-        `Duplicate upstream prefix "${spec.prefix}" in registry — prefixes must be unique.`
+        `Duplicate upstream prefix "${spec.prefix}" in registry - prefixes must be unique.`
       );
     }
     seenPrefixes.add(spec.prefix);
@@ -91,7 +91,7 @@ export async function mountUpstreams(
   return handles;
 }
 
-/** Options accepted by mountUpstream — used by tests to override defaults. */
+/** Options accepted by mountUpstream - used by tests to override defaults. */
 export interface MountOptions {
   /** Override bin resolution. Used by tests pointing at a fixture script. */
   binPath?: string;
@@ -155,7 +155,7 @@ export async function mountUpstream(
     });
   }
 
-  // Runtime fail-fast hook — overridable for tests.
+  // Runtime fail-fast hook - overridable for tests.
   transport.onclose = () => onExit(spec, 'close');
   transport.onerror = (err) => onExit(spec, err);
 
@@ -180,7 +180,7 @@ async function registerUpstream(
   client: Client,
   transport: StdioClientTransport
 ): Promise<UpstreamHandle> {
-  // We only call list* for capabilities the upstream advertises — calling tools/list against
+  // We only call list* for capabilities the upstream advertises - calling tools/list against
   // a server without `tools` capability would return -32601 Method not found.
   const upstreamCaps = client.getServerCapabilities() ?? {};
 
@@ -246,7 +246,7 @@ async function registerUpstream(
           title: resource.title,
         },
         async (uri) => {
-          // Forward verbatim — the upstream is the source of truth for the
+          // Forward verbatim - the upstream is the source of truth for the
           // ReadResourceResult shape (`{ contents: [...] }`); if it's
           // schema-violating the parent's framework will throw at response time,
           // matching the same trust model as tool/prompt forwarding.
@@ -302,7 +302,7 @@ function resolveUpstreamBin(spec: UpstreamSpec): string {
     pkgJsonPath = require.resolve(`${spec.packageName}/package.json`);
   } catch (error) {
     throw new Error(
-      `[${spec.label}] cannot resolve package "${spec.packageName}" — is it installed? (${stringifyError(error)})`
+      `[${spec.label}] cannot resolve package "${spec.packageName}" - is it installed? (${stringifyError(error)})`
     );
   }
 
@@ -312,7 +312,7 @@ function resolveUpstreamBin(spec: UpstreamSpec): string {
   if (typeof binField === 'string') {
     binRel = binField;
   } else if (binField && typeof binField === 'object') {
-    // Prefer the bin entry whose name matches the package basename — that's the convention
+    // Prefer the bin entry whose name matches the package basename - that's the convention
     // for npm packages that ship multiple binaries (one of which is the "main" tool).
     const basename = spec.packageName.split('/').pop() ?? spec.packageName;
     binRel = binField[basename] ?? Object.values(binField)[0];
@@ -331,13 +331,13 @@ function resolveUpstreamBin(spec: UpstreamSpec): string {
  *
  * Returns undefined when there's no useful per-property shape to register: either the schema is
  * not an object schema, or its properties are empty/absent. In that case the caller omits
- * `inputSchema` and the SDK skips parent-side validation entirely — args are forwarded as-is to
+ * `inputSchema` and the SDK skips parent-side validation entirely - args are forwarded as-is to
  * the upstream, which is the source of truth. This handles `type: object` schemas with no
  * declared properties (e.g. tools that accept free-form keys) without rejecting calls.
  *
  * This is intentionally limited to the JSON Schema constructs MCP tool inputs actually use in
  * practice: primitive types (string/number/integer/boolean), enum, description, required, and
- * arrays. Nested objects and combinators (oneOf/anyOf/allOf) fall back to z.any() — the
+ * arrays. Nested objects and combinators (oneOf/anyOf/allOf) fall back to z.any() - the
  * upstream still validates the call, so this is safe.
  *
  * Defaults (`default:`) are intentionally NOT carried into the parent's Zod shape. The upstream
@@ -376,7 +376,7 @@ function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
 
   if (Array.isArray(s.enum) && s.enum.length > 0) {
     // Zod's z.enum requires string literals; enum values may be numbers/booleans, so we
-    // build z.literal()s and union them. z.union requires at least 2 members — for a
+    // build z.literal()s and union them. z.union requires at least 2 members - for a
     // single-value enum, return the literal directly. The double cast is needed because
     // TS can't statically prove `literals` has 2+ elements at this point.
     const literals = s.enum.map((v) => z.literal(v as string | number | boolean));
@@ -400,13 +400,13 @@ function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
         zodSchema = z.array(s.items ? jsonValueSchemaToZod(s.items) : z.any());
         break;
       default:
-        // Object subschemas, oneOf/anyOf, etc. — pass through; upstream re-validates.
+        // Object subschemas, oneOf/anyOf, etc. - pass through; upstream re-validates.
         zodSchema = z.any();
     }
   }
 
   if (s.description) zodSchema = zodSchema.describe(s.description);
-  // Defaults are intentionally not applied here — the upstream is the source of truth and
+  // Defaults are intentionally not applied here - the upstream is the source of truth and
   // applies them itself. Carrying them through would apply defaults twice and could mask
   // cases where `undefined` is meaningful to the upstream tool.
   return zodSchema;
@@ -418,7 +418,7 @@ function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
  * are required, others are optional.
  *
  * Note: per the MCP spec (https://spec.modelcontextprotocol.io), prompt arguments are always
- * strings — there is no typed-prompt-arg construct. Don't extend this to other Zod types.
+ * strings - there is no typed-prompt-arg construct. Don't extend this to other Zod types.
  */
 function promptArgsToZodShape(
   args: Array<{ name: string; description?: string; required?: boolean }> | undefined

--- a/src/upstreams/mount.ts
+++ b/src/upstreams/mount.ts
@@ -136,7 +136,10 @@ export async function mountUpstream(
     await client.connect(transport);
   } catch (error) {
     // Symmetric with the post-connect failure path: the spawned child must not leak even when
-    // the very first handshake fails.
+    // the very first handshake fails. Detach onclose/onerror before closing so the fail-fast
+    // handler doesn't fire during the awaited close and swallow this error via process.exit.
+    transport.onclose = undefined;
+    transport.onerror = undefined;
     try {
       await transport.close();
     } catch {
@@ -162,9 +165,14 @@ export async function mountUpstream(
   try {
     return await registerUpstream(server, spec, client, transport);
   } catch (error) {
-    // Anything failing past connect (URI collision, listTools error, registration error)
-    // leaves the child process running. Tear it down before propagating so the caller's
-    // process doesn't leak children.
+    // Anything failing past connect (URI collision, listTools error, registration error) leaves
+    // the child process running. Tear it down before propagating so the caller's process doesn't
+    // leak children. Detach onclose/onerror first: `close()` awaits the child's 'close' event,
+    // which fires this transport's onclose synchronously (SDK stdio.js) - without detachment the
+    // fail-fast handler would call process.exit(1) inside the await and this throw would never
+    // reach the caller.
+    transport.onclose = undefined;
+    transport.onerror = undefined;
     try {
       await transport.close();
     } catch {
@@ -189,14 +197,15 @@ async function registerUpstream(
   const promptNames: string[] = [];
 
   if (upstreamCaps.tools) {
-    const { tools } = await client.listTools();
+    const tools = await listAllPages((cursor) => client.listTools({ cursor }), 'tools');
     for (const tool of tools) {
-      // Naming: `<spec.prefix>_<tool.name>`. Note that an upstream may already namespace its own
-      // tools (e.g. the React MCP exports tools like `react_get_component_api`) so the user can
-      // see double-prefixed names like `react_react_get_component_api`. That's deliberate here:
-      // we don't strip a leading `<prefix>_` from the upstream's name because doing so risks
-      // collision when a future upstream genuinely exports an unprefixed tool with the same
-      // basename. A follow-up may revisit this with explicit registry-level guidance.
+      // Naming: `<spec.prefix>_<tool.name>`. Upstream tools are expected to be unprefixed
+      // (e.g. the React MCP exports `get_component_api`, `create_app`, etc.), which after
+      // prefixing yields `react_get_component_api`. If a future upstream ALREADY namespaces
+      // its own tools we'd see double-prefixed names like `react_react_<name>`; we
+      // deliberately don't strip a leading `<prefix>_` because doing so risks collision when
+      // a different upstream genuinely exports an unprefixed tool with the same basename.
+      // A follow-up may revisit this with registry-level guidance.
       const mountedName = `${spec.prefix}_${tool.name}`;
       const inputShape = jsonObjectSchemaToZodShape(tool.inputSchema);
       const config: {
@@ -228,7 +237,7 @@ async function registerUpstream(
   }
 
   if (upstreamCaps.resources) {
-    const { resources } = await client.listResources();
+    const resources = await listAllPages((cursor) => client.listResources({ cursor }), 'resources');
     for (const resource of resources) {
       const owner = resourceOwners.get(resource.uri);
       if (owner) {
@@ -259,7 +268,7 @@ async function registerUpstream(
   }
 
   if (upstreamCaps.prompts) {
-    const { prompts } = await client.listPrompts();
+    const prompts = await listAllPages((cursor) => client.listPrompts({ cursor }), 'prompts');
     for (const prompt of prompts) {
       const mountedName = `${spec.prefix}_${prompt.name}`;
       const argsShape = promptArgsToZodShape(prompt.arguments);
@@ -437,4 +446,31 @@ function promptArgsToZodShape(
 function stringifyError(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+/**
+ * Drive a paginated `list*` MCP call to completion. All three list result types
+ * (tools/resources/prompts) extend `PaginatedResult` and carry an optional `nextCursor` when the
+ * server has more items than fit in one page. Callers passed a single call before this helper
+ * existed and would silently drop everything past the first page.
+ *
+ * The `key` picks the array field on each page (`tools` | `resources` | `prompts`). A bounded
+ * iteration count acts as a runaway-loop guard against a misbehaving upstream that returns the
+ * same cursor forever.
+ */
+async function listAllPages<
+  K extends string,
+  P extends { nextCursor?: string } & { [Q in K]: readonly unknown[] },
+>(fetchPage: (cursor: string | undefined) => Promise<P>, key: K): Promise<P[K]> {
+  const out: unknown[] = [];
+  let cursor: string | undefined = undefined;
+  // Cap iterations so a broken upstream can't spin forever. 1000 pages at the SDK's default
+  // page sizes covers any realistic upstream by orders of magnitude.
+  for (let i = 0; i < 1000; i++) {
+    const page = await fetchPage(cursor);
+    out.push(...page[key]);
+    if (!page.nextCursor) return out as unknown as P[K];
+    cursor = page.nextCursor;
+  }
+  throw new Error(`listAllPages(${key}): exceeded 1000 pages - upstream likely misbehaving`);
 }

--- a/src/upstreams/mount.ts
+++ b/src/upstreams/mount.ts
@@ -25,6 +25,23 @@ export interface UpstreamHandle {
 const resourceOwners = new Map<string, UpstreamSpec>();
 let shuttingDown = false;
 
+/**
+ * Own version, read once from this package's package.json. Forwarded to upstream MCP servers as
+ * the connecting client's version so their logs are useful when debugging which parent
+ * connected. Falls back to '0.0.0' if the lookup fails for any reason — non-fatal.
+ */
+const OWN_VERSION = readOwnVersion();
+function readOwnVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    // The compiled artifact lives at build/upstreams/mount.js, so the package.json is two levels up.
+    const pkg = require('../../package.json') as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
 /** Called from the entrypoint's shutdown handler before closing transports. */
 export function markShutdown(): void {
   shuttingDown = true;
@@ -46,12 +63,19 @@ export function _resetForTesting(): void {
  * them on `server` under namespaced names (resources keep their original URI; collisions throw).
  *
  * Throws on any failure — the caller is expected to log and exit non-zero.
+ *
+ * The optional `upstreams` parameter exists for tests; production callers pass nothing and the
+ * module-level `UPSTREAMS` list is used.
  */
-export async function mountUpstreams(server: McpServer): Promise<UpstreamHandle[]> {
+export async function mountUpstreams(
+  server: McpServer,
+  upstreams: ReadonlyArray<UpstreamSpec> = UPSTREAMS
+): Promise<UpstreamHandle[]> {
   // Cheap insurance against typos in the registry: two upstreams sharing a prefix would silently
-  // collide on every same-named tool/prompt and behave non-deterministically. Detect at startup.
+  // collide on every same-named tool/prompt and behave non-deterministically. Detect at startup
+  // so the failure mode is "server fails to boot with a clear error", not "calls misroute".
   const seenPrefixes = new Set<string>();
-  for (const spec of UPSTREAMS) {
+  for (const spec of upstreams) {
     if (seenPrefixes.has(spec.prefix)) {
       throw new Error(
         `Duplicate upstream prefix "${spec.prefix}" in registry — prefixes must be unique.`
@@ -61,7 +85,7 @@ export async function mountUpstreams(server: McpServer): Promise<UpstreamHandle[
   }
 
   const handles: UpstreamHandle[] = [];
-  for (const spec of UPSTREAMS) {
+  for (const spec of upstreams) {
     handles.push(await mountUpstream(server, spec));
   }
   return handles;
@@ -104,13 +128,20 @@ export async function mountUpstream(
   });
 
   const client = new Client(
-    { name: 'ui5-webcomponents-mcp-server', version: '0.0.0' },
+    { name: 'ui5-webcomponents-mcp-server', version: OWN_VERSION },
     { capabilities: {} }
   );
 
   try {
     await client.connect(transport);
   } catch (error) {
+    // Symmetric with the post-connect failure path: the spawned child must not leak even when
+    // the very first handshake fails.
+    try {
+      await transport.close();
+    } catch {
+      /* best-effort */
+    }
     throw new Error(`[${spec.label}] failed to connect: ${stringifyError(error)}`);
   }
 
@@ -160,6 +191,12 @@ async function registerUpstream(
   if (upstreamCaps.tools) {
     const { tools } = await client.listTools();
     for (const tool of tools) {
+      // Naming: `<spec.prefix>_<tool.name>`. Note that an upstream may already namespace its own
+      // tools (e.g. the React MCP exports tools like `react_get_component_api`) so the user can
+      // see double-prefixed names like `react_react_get_component_api`. That's deliberate here:
+      // we don't strip a leading `<prefix>_` from the upstream's name because doing so risks
+      // collision when a future upstream genuinely exports an unprefixed tool with the same
+      // basename. A follow-up may revisit this with explicit registry-level guidance.
       const mountedName = `${spec.prefix}_${tool.name}`;
       const inputShape = jsonObjectSchemaToZodShape(tool.inputSchema);
       const config: {
@@ -171,8 +208,11 @@ async function registerUpstream(
         annotations: tool.annotations,
       };
       if (inputShape) config.inputSchema = inputShape;
-      // Handler signature differs based on whether inputSchema is set; cast through `unknown`
-      // since the upstream server is the actual validator.
+      // The SDK overloads `registerTool` so its handler-arg type depends on whether inputSchema
+      // is supplied. We're populating that field dynamically based on what the upstream returns,
+      // so TS can't pick the right overload at compile time. Casting through `unknown` is the
+      // narrowest workaround until the SDK exposes a less-overloaded variant; the upstream is
+      // the actual validator regardless.
       server.registerTool(
         mountedName,
         config as Parameters<McpServer['registerTool']>[1],
@@ -287,13 +327,22 @@ function resolveUpstreamBin(spec: UpstreamSpec): string {
 
 /**
  * Convert an MCP tool's JSON Schema (always `type: object` per spec) into the raw-shape form
- * (Record<string, ZodTypeAny>) that `McpServer.registerTool` expects. Returns undefined if the
- * schema has no properties — `registerTool` is fine omitting `inputSchema` in that case.
+ * (Record<string, ZodTypeAny>) that `McpServer.registerTool` expects.
+ *
+ * Returns undefined when there's no useful per-property shape to register: either the schema is
+ * not an object schema, or its properties are empty/absent. In that case the caller omits
+ * `inputSchema` and the SDK skips parent-side validation entirely — args are forwarded as-is to
+ * the upstream, which is the source of truth. This handles `type: object` schemas with no
+ * declared properties (e.g. tools that accept free-form keys) without rejecting calls.
  *
  * This is intentionally limited to the JSON Schema constructs MCP tool inputs actually use in
- * practice: primitive types (string/number/integer/boolean), enum, default, description, and
- * required. Nested objects and combinators (oneOf/anyOf/allOf) fall back to z.any() — the
+ * practice: primitive types (string/number/integer/boolean), enum, description, required, and
+ * arrays. Nested objects and combinators (oneOf/anyOf/allOf) fall back to z.any() — the
  * upstream still validates the call, so this is safe.
+ *
+ * Defaults (`default:`) are intentionally NOT carried into the parent's Zod shape. The upstream
+ * is the single source of truth for validation and default-application; applying defaults twice
+ * could mask cases where `undefined` is meaningful to the upstream tool.
  */
 function jsonObjectSchemaToZodShape(schema: unknown): Record<string, ZodTypeAny> | undefined {
   if (!schema || typeof schema !== 'object') return undefined;
@@ -320,7 +369,6 @@ function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
     type?: string;
     enum?: unknown[];
     description?: string;
-    default?: unknown;
     items?: unknown;
   };
 
@@ -358,7 +406,9 @@ function jsonValueSchemaToZod(schema: unknown): ZodTypeAny {
   }
 
   if (s.description) zodSchema = zodSchema.describe(s.description);
-  if (s.default !== undefined) zodSchema = zodSchema.default(s.default as never);
+  // Defaults are intentionally not applied here — the upstream is the source of truth and
+  // applies them itself. Carrying them through would apply defaults twice and could mask
+  // cases where `undefined` is meaningful to the upstream tool.
   return zodSchema;
 }
 

--- a/src/upstreams/registry.ts
+++ b/src/upstreams/registry.ts
@@ -1,0 +1,22 @@
+/**
+ * Hardcoded list of upstream MCP servers to mount as namespaced tools/resources/prompts.
+ *
+ * Adding a new framework MCP (Angular, Vue, ...) is a one-entry PR here plus adding the
+ * package to `dependencies` in package.json.
+ */
+export interface UpstreamSpec {
+    /** Used as prefix for mounted tool & prompt names: e.g. "react" -> tools become "react_<name>". */
+    prefix: string;
+    /** Human-readable label for logs/errors. */
+    label: string;
+    /** npm package name; the bin to spawn is resolved via its package.json. */
+    packageName: string;
+}
+
+export const UPSTREAMS: UpstreamSpec[] = [
+    {
+        prefix: "react",
+        label: "UI5 Web Components for React",
+        packageName: "@ui5/webcomponents-react-mcp",
+    },
+];

--- a/src/upstreams/registry.ts
+++ b/src/upstreams/registry.ts
@@ -5,18 +5,18 @@
  * package to `dependencies` in package.json.
  */
 export interface UpstreamSpec {
-    /** Used as prefix for mounted tool & prompt names: e.g. "react" -> tools become "react_<name>". */
-    prefix: string;
-    /** Human-readable label for logs/errors. */
-    label: string;
-    /** npm package name; the bin to spawn is resolved via its package.json. */
-    packageName: string;
+  /** Used as prefix for mounted tool & prompt names: e.g. "react" -> tools become "react_<name>". */
+  prefix: string;
+  /** Human-readable label for logs/errors. */
+  label: string;
+  /** npm package name; the bin to spawn is resolved via its package.json. */
+  packageName: string;
 }
 
 export const UPSTREAMS: UpstreamSpec[] = [
-    {
-        prefix: "react",
-        label: "UI5 Web Components for React",
-        packageName: "@ui5/webcomponents-react-mcp",
-    },
+  {
+    prefix: 'react',
+    label: 'UI5 Web Components for React',
+    packageName: '@ui5/webcomponents-react-mcp',
+  },
 ];

--- a/test/fixtures/mock_empty_upstream.mjs
+++ b/test/fixtures/mock_empty_upstream.mjs
@@ -1,0 +1,18 @@
+/**
+ * Mock upstream MCP server with no advertised capabilities — used to verify the mount layer
+ * gracefully short-circuits when the upstream advertises nothing rather than calling tools/list
+ * or resources/list (which would return -32601 Method not found on a server without that
+ * capability).
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = new McpServer(
+  { name: 'mock-empty-upstream', version: '1.0.0' },
+  { capabilities: {} } // no tools, resources, or prompts
+);
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));
+
+await server.connect(new StdioServerTransport());

--- a/test/fixtures/mock_empty_upstream.mjs
+++ b/test/fixtures/mock_empty_upstream.mjs
@@ -1,5 +1,5 @@
 /**
- * Mock upstream MCP server with no advertised capabilities — used to verify the mount layer
+ * Mock upstream MCP server with no advertised capabilities - used to verify the mount layer
  * gracefully short-circuits when the upstream advertises nothing rather than calling tools/list
  * or resources/list (which would return -32601 Method not found on a server without that
  * capability).

--- a/test/fixtures/mock_upstream.mjs
+++ b/test/fixtures/mock_upstream.mjs
@@ -1,7 +1,7 @@
 /**
  * Mock upstream MCP server used by upstreams.test.ts.
  *
- * Registers one of each: tool, resource, prompt — so the mount layer's three forwarding paths
+ * Registers one of each: tool, resource, prompt - so the mount layer's three forwarding paths
  * are all exercised. Also registers a second tool with a richer input schema (enum, integer,
  * array, optional-with-default) so the JSON-Schema → Zod converter is covered end-to-end.
  * Designed to run as `node mock_upstream.mjs`.

--- a/test/fixtures/mock_upstream.mjs
+++ b/test/fixtures/mock_upstream.mjs
@@ -1,0 +1,52 @@
+/**
+ * Mock upstream MCP server used by upstreams.test.ts.
+ *
+ * Registers one of each: tool, resource, prompt — so the mount layer's three forwarding paths
+ * are all exercised. Designed to run as `node mock_upstream.mjs`.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const server = new McpServer(
+    { name: 'mock-upstream', version: '1.0.0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+);
+
+server.registerTool(
+    'echo',
+    {
+        description: 'Echoes the provided message',
+        inputSchema: { message: z.string() },
+    },
+    async ({ message }) => ({
+        content: [{ type: 'text', text: `echo: ${message}` }],
+    })
+);
+
+server.registerResource(
+    'mock-doc',
+    'mock://doc',
+    { description: 'A mock document', mimeType: 'text/plain' },
+    async (uri) => ({
+        contents: [{ uri: uri.toString(), mimeType: 'text/plain', text: 'mock body' }],
+    })
+);
+
+server.registerPrompt(
+    'greet',
+    {
+        description: 'Generates a greeting',
+        argsSchema: { name: z.string() },
+    },
+    async ({ name }) => ({
+        messages: [
+            {
+                role: 'user',
+                content: { type: 'text', text: `hello ${name}` },
+            },
+        ],
+    })
+);
+
+await server.connect(new StdioServerTransport());

--- a/test/fixtures/mock_upstream.mjs
+++ b/test/fixtures/mock_upstream.mjs
@@ -2,7 +2,9 @@
  * Mock upstream MCP server used by upstreams.test.ts.
  *
  * Registers one of each: tool, resource, prompt — so the mount layer's three forwarding paths
- * are all exercised. Designed to run as `node mock_upstream.mjs`.
+ * are all exercised. Also registers a second tool with a richer input schema (enum, integer,
+ * array, optional-with-default) so the JSON-Schema → Zod converter is covered end-to-end.
+ * Designed to run as `node mock_upstream.mjs`.
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -21,6 +23,30 @@ server.registerTool(
   },
   async ({ message }) => ({
     content: [{ type: 'text', text: `echo: ${message}` }],
+  })
+);
+
+// Second tool: schema exercises enum, integer, array-of-string, and an optional with default.
+// The mount layer should still register it and the upstream remains the source of truth for
+// validation (defaults are intentionally NOT carried into the parent's Zod shape).
+server.registerTool(
+  'format',
+  {
+    description: 'Formats inputs in a chosen style',
+    inputSchema: {
+      style: z.enum(['short', 'long']),
+      count: z.number().int(),
+      tags: z.array(z.string()),
+      verbose: z.boolean().optional().default(false),
+    },
+  },
+  async ({ style, count, tags, verbose }) => ({
+    content: [
+      {
+        type: 'text',
+        text: `style=${style} count=${count} tags=[${tags.join(',')}] verbose=${verbose}`,
+      },
+    ],
   })
 );
 
@@ -48,5 +74,10 @@ server.registerPrompt(
     ],
   })
 );
+
+// Cleaner Ctrl-C / supervised teardown when a test hangs and the harness sends SIGTERM.
+// stdio EOF still works without this; this just makes manual debugging less surprising.
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));
 
 await server.connect(new StdioServerTransport());

--- a/test/fixtures/mock_upstream.mjs
+++ b/test/fixtures/mock_upstream.mjs
@@ -9,44 +9,44 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 
 const server = new McpServer(
-    { name: 'mock-upstream', version: '1.0.0' },
-    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  { name: 'mock-upstream', version: '1.0.0' },
+  { capabilities: { tools: {}, resources: {}, prompts: {} } }
 );
 
 server.registerTool(
-    'echo',
-    {
-        description: 'Echoes the provided message',
-        inputSchema: { message: z.string() },
-    },
-    async ({ message }) => ({
-        content: [{ type: 'text', text: `echo: ${message}` }],
-    })
+  'echo',
+  {
+    description: 'Echoes the provided message',
+    inputSchema: { message: z.string() },
+  },
+  async ({ message }) => ({
+    content: [{ type: 'text', text: `echo: ${message}` }],
+  })
 );
 
 server.registerResource(
-    'mock-doc',
-    'mock://doc',
-    { description: 'A mock document', mimeType: 'text/plain' },
-    async (uri) => ({
-        contents: [{ uri: uri.toString(), mimeType: 'text/plain', text: 'mock body' }],
-    })
+  'mock-doc',
+  'mock://doc',
+  { description: 'A mock document', mimeType: 'text/plain' },
+  async (uri) => ({
+    contents: [{ uri: uri.toString(), mimeType: 'text/plain', text: 'mock body' }],
+  })
 );
 
 server.registerPrompt(
-    'greet',
-    {
-        description: 'Generates a greeting',
-        argsSchema: { name: z.string() },
-    },
-    async ({ name }) => ({
-        messages: [
-            {
-                role: 'user',
-                content: { type: 'text', text: `hello ${name}` },
-            },
-        ],
-    })
+  'greet',
+  {
+    description: 'Generates a greeting',
+    argsSchema: { name: z.string() },
+  },
+  async ({ name }) => ({
+    messages: [
+      {
+        role: 'user',
+        content: { type: 'text', text: `hello ${name}` },
+      },
+    ],
+  })
 );
 
 await server.connect(new StdioServerTransport());

--- a/test/upstreams.test.ts
+++ b/test/upstreams.test.ts
@@ -1,0 +1,143 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import anyTest, { TestFn } from 'ava';
+
+import { mountUpstream, UPSTREAMS } from '../src/upstreams/index.js';
+import { _resetForTesting } from '../src/upstreams/mount.js';
+
+const test = anyTest as TestFn;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOCK_BIN = path.join(__dirname, 'fixtures', 'mock_upstream.mjs');
+
+test.beforeEach(() => {
+  _resetForTesting();
+});
+
+/**
+ * Drive the mount layer against the in-tree mock upstream. Asserts:
+ *   - Tools register under `<prefix>_<originalName>` and forward.
+ *   - Resources register with their upstream URI verbatim and forward.
+ *   - Prompts register under `<prefix>_<originalName>` and forward.
+ *
+ * Serial: tests share module-scoped resourceOwners and spawn children — keep teardown
+ * deterministic.
+ */
+test.serial(
+  'mountUpstream namespaces and forwards tools, resources, and prompts',
+  async (t) => {
+    const server = new McpServer(
+      { name: 'host', version: '0' },
+      { capabilities: { tools: {}, resources: {}, prompts: {} } }
+    );
+
+    const handle = await mountUpstream(
+      server,
+      { prefix: 'mock', label: 'Mock Upstream', packageName: 'unused' },
+      { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+    );
+
+    try {
+      t.deepEqual(handle.toolNames, ['mock_echo']);
+      t.deepEqual(handle.resourceUris, ['mock://doc']);
+      t.deepEqual(handle.promptNames, ['mock_greet']);
+
+      // Forward a tool call through the upstream client — this exercises the same path the
+      // mounted handler uses (server.registerTool's callback delegates to it).
+      const toolResult = await handle.client.callTool({
+        name: 'echo',
+        arguments: { message: 'hi' },
+      });
+      const toolContent = (toolResult.content as Array<{ type: string; text?: string }>)?.[0];
+      t.is(toolContent?.type, 'text');
+      t.is(toolContent?.text, 'echo: hi');
+
+      const readResult = await handle.client.readResource({ uri: 'mock://doc' });
+      const resourceContent = (readResult.contents as Array<{ text?: string }>)?.[0];
+      t.is(resourceContent?.text, 'mock body');
+
+      const promptResult = await handle.client.getPrompt({
+        name: 'greet',
+        arguments: { name: 'world' },
+      });
+      const promptText = (
+        promptResult.messages?.[0]?.content as { type: string; text?: string }
+      )?.text;
+      t.is(promptText, 'hello world');
+    } finally {
+      await handle.transport.close();
+    }
+  }
+);
+
+/**
+ * Mounts the real React MCP via the registry and asserts its expected tools and resources show
+ * up. We don't call its tools — that's the React team's contract — only that the mount plumbing
+ * sees them.
+ */
+test.serial(
+  'mountUpstream against real React MCP exposes expected tools and llms.txt resource',
+  async (t) => {
+    const reactSpec = UPSTREAMS.find(u => u.prefix === 'react');
+    t.truthy(reactSpec, 'React entry should be in UPSTREAMS');
+
+    const server = new McpServer(
+      { name: 'host', version: '0' },
+      { capabilities: { tools: {}, resources: {}, prompts: {} } }
+    );
+
+    const handle = await mountUpstream(server, reactSpec!, { onUpstreamExit: () => {} });
+
+    try {
+      const expectedTools = [
+        'react_create_app',
+        'react_get_component_api',
+        'react_get_documentation',
+        'react_get_public_utils',
+        'react_list_components',
+      ];
+      for (const name of expectedTools) {
+        t.true(
+          handle.toolNames.includes(name),
+          `Expected mounted tool ${name}, got: ${handle.toolNames.join(', ')}`
+        );
+      }
+      t.deepEqual(handle.resourceUris, ['file:///llms.txt']);
+      t.deepEqual(handle.promptNames, []);
+    } finally {
+      await handle.transport.close();
+    }
+  }
+);
+
+/** Resource URI collision across two mounts must hard-fail to surface misconfiguration early. */
+test.serial(
+  'mountUpstream throws on resource URI collision across upstreams',
+  async (t) => {
+    const server = new McpServer(
+      { name: 'host', version: '0' },
+      { capabilities: { tools: {}, resources: {}, prompts: {} } }
+    );
+
+    const a = await mountUpstream(
+      server,
+      { prefix: 'a', label: 'A', packageName: 'unused' },
+      { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+    );
+
+    // Second mount of the same fixture would re-register `mock://doc` — must throw.
+    await t.throwsAsync(
+      () =>
+        mountUpstream(
+          server,
+          { prefix: 'b', label: 'B', packageName: 'unused' },
+          { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+        ),
+      { message: /Resource URI collision/ }
+    );
+
+    await a.transport.close();
+  }
+);

--- a/test/upstreams.test.ts
+++ b/test/upstreams.test.ts
@@ -6,8 +6,12 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import anyTest, { TestFn } from 'ava';
 
-import { mountUpstream, mountUpstreams, UPSTREAMS } from '../src/upstreams/index.js';
-import { _resetForTesting } from '../src/upstreams/index.js';
+import {
+  mountUpstream,
+  mountUpstreams,
+  UPSTREAMS,
+  _resetForTesting,
+} from '../src/upstreams/index.js';
 
 const test = anyTest as TestFn;
 
@@ -238,6 +242,50 @@ test.serial('mountUpstream throws on resource URI collision across upstreams', a
       ),
     { message: /Resource URI collision/ }
   );
+
+  await a.transport.close();
+});
+
+/**
+ * Regression for the onclose-swallows-error bug: when registerUpstream throws, the catch block
+ * awaits transport.close(). The SDK's stdio transport fires `onclose` from the child's 'close'
+ * event synchronously inside that await. If onclose isn't detached first, the fail-fast handler
+ * (defaultOnUpstreamExit) would call process.exit(1) and the useful error would never reach the
+ * caller. This test drives the failing mount with an onUpstreamExit that ASSERTS if invoked,
+ * proving the mount code detached the handler before closing.
+ */
+test.serial('mountUpstream error path does not fire onUpstreamExit during cleanup', async (t) => {
+  const server = new McpServer(
+    { name: 'host', version: '0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  );
+
+  const a = await mountUpstream(
+    server,
+    { prefix: 'a', label: 'A', packageName: 'unused' },
+    { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+  );
+
+  let onExitCalls = 0;
+  await t.throwsAsync(
+    () =>
+      mountUpstream(
+        server,
+        { prefix: 'b', label: 'B', packageName: 'unused' },
+        {
+          binPath: MOCK_BIN,
+          // If the mount layer forgets to detach onclose before transport.close(), this fires
+          // during error cleanup and (in production) would swallow the collision error via
+          // process.exit. In the test we just count calls and assert zero.
+          onUpstreamExit: () => {
+            onExitCalls++;
+          },
+        }
+      ),
+    { message: /Resource URI collision/ }
+  );
+
+  t.is(onExitCalls, 0, 'onUpstreamExit must not fire during error-path cleanup');
 
   await a.transport.close();
 });

--- a/test/upstreams.test.ts
+++ b/test/upstreams.test.ts
@@ -25,52 +25,48 @@ test.beforeEach(() => {
  * Serial: tests share module-scoped resourceOwners and spawn children — keep teardown
  * deterministic.
  */
-test.serial(
-  'mountUpstream namespaces and forwards tools, resources, and prompts',
-  async (t) => {
-    const server = new McpServer(
-      { name: 'host', version: '0' },
-      { capabilities: { tools: {}, resources: {}, prompts: {} } }
-    );
+test.serial('mountUpstream namespaces and forwards tools, resources, and prompts', async (t) => {
+  const server = new McpServer(
+    { name: 'host', version: '0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  );
 
-    const handle = await mountUpstream(
-      server,
-      { prefix: 'mock', label: 'Mock Upstream', packageName: 'unused' },
-      { binPath: MOCK_BIN, onUpstreamExit: () => {} }
-    );
+  const handle = await mountUpstream(
+    server,
+    { prefix: 'mock', label: 'Mock Upstream', packageName: 'unused' },
+    { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+  );
 
-    try {
-      t.deepEqual(handle.toolNames, ['mock_echo']);
-      t.deepEqual(handle.resourceUris, ['mock://doc']);
-      t.deepEqual(handle.promptNames, ['mock_greet']);
+  try {
+    t.deepEqual(handle.toolNames, ['mock_echo']);
+    t.deepEqual(handle.resourceUris, ['mock://doc']);
+    t.deepEqual(handle.promptNames, ['mock_greet']);
 
-      // Forward a tool call through the upstream client — this exercises the same path the
-      // mounted handler uses (server.registerTool's callback delegates to it).
-      const toolResult = await handle.client.callTool({
-        name: 'echo',
-        arguments: { message: 'hi' },
-      });
-      const toolContent = (toolResult.content as Array<{ type: string; text?: string }>)?.[0];
-      t.is(toolContent?.type, 'text');
-      t.is(toolContent?.text, 'echo: hi');
+    // Forward a tool call through the upstream client — this exercises the same path the
+    // mounted handler uses (server.registerTool's callback delegates to it).
+    const toolResult = await handle.client.callTool({
+      name: 'echo',
+      arguments: { message: 'hi' },
+    });
+    const toolContent = (toolResult.content as Array<{ type: string; text?: string }>)?.[0];
+    t.is(toolContent?.type, 'text');
+    t.is(toolContent?.text, 'echo: hi');
 
-      const readResult = await handle.client.readResource({ uri: 'mock://doc' });
-      const resourceContent = (readResult.contents as Array<{ text?: string }>)?.[0];
-      t.is(resourceContent?.text, 'mock body');
+    const readResult = await handle.client.readResource({ uri: 'mock://doc' });
+    const resourceContent = (readResult.contents as Array<{ text?: string }>)?.[0];
+    t.is(resourceContent?.text, 'mock body');
 
-      const promptResult = await handle.client.getPrompt({
-        name: 'greet',
-        arguments: { name: 'world' },
-      });
-      const promptText = (
-        promptResult.messages?.[0]?.content as { type: string; text?: string }
-      )?.text;
-      t.is(promptText, 'hello world');
-    } finally {
-      await handle.transport.close();
-    }
+    const promptResult = await handle.client.getPrompt({
+      name: 'greet',
+      arguments: { name: 'world' },
+    });
+    const promptText = (promptResult.messages?.[0]?.content as { type: string; text?: string })
+      ?.text;
+    t.is(promptText, 'hello world');
+  } finally {
+    await handle.transport.close();
   }
-);
+});
 
 /**
  * Mounts the real React MCP via the registry and asserts its expected tools and resources show
@@ -80,7 +76,7 @@ test.serial(
 test.serial(
   'mountUpstream against real React MCP exposes expected tools and llms.txt resource',
   async (t) => {
-    const reactSpec = UPSTREAMS.find(u => u.prefix === 'react');
+    const reactSpec = UPSTREAMS.find((u) => u.prefix === 'react');
     t.truthy(reactSpec, 'React entry should be in UPSTREAMS');
 
     const server = new McpServer(
@@ -113,31 +109,28 @@ test.serial(
 );
 
 /** Resource URI collision across two mounts must hard-fail to surface misconfiguration early. */
-test.serial(
-  'mountUpstream throws on resource URI collision across upstreams',
-  async (t) => {
-    const server = new McpServer(
-      { name: 'host', version: '0' },
-      { capabilities: { tools: {}, resources: {}, prompts: {} } }
-    );
+test.serial('mountUpstream throws on resource URI collision across upstreams', async (t) => {
+  const server = new McpServer(
+    { name: 'host', version: '0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  );
 
-    const a = await mountUpstream(
-      server,
-      { prefix: 'a', label: 'A', packageName: 'unused' },
-      { binPath: MOCK_BIN, onUpstreamExit: () => {} }
-    );
+  const a = await mountUpstream(
+    server,
+    { prefix: 'a', label: 'A', packageName: 'unused' },
+    { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+  );
 
-    // Second mount of the same fixture would re-register `mock://doc` — must throw.
-    await t.throwsAsync(
-      () =>
-        mountUpstream(
-          server,
-          { prefix: 'b', label: 'B', packageName: 'unused' },
-          { binPath: MOCK_BIN, onUpstreamExit: () => {} }
-        ),
-      { message: /Resource URI collision/ }
-    );
+  // Second mount of the same fixture would re-register `mock://doc` — must throw.
+  await t.throwsAsync(
+    () =>
+      mountUpstream(
+        server,
+        { prefix: 'b', label: 'B', packageName: 'unused' },
+        { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+      ),
+    { message: /Resource URI collision/ }
+  );
 
-    await a.transport.close();
-  }
-);
+  await a.transport.close();
+});

--- a/test/upstreams.test.ts
+++ b/test/upstreams.test.ts
@@ -2,15 +2,18 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import anyTest, { TestFn } from 'ava';
 
-import { mountUpstream, UPSTREAMS } from '../src/upstreams/index.js';
-import { _resetForTesting } from '../src/upstreams/mount.js';
+import { mountUpstream, mountUpstreams, UPSTREAMS } from '../src/upstreams/index.js';
+import { _resetForTesting } from '../src/upstreams/index.js';
 
 const test = anyTest as TestFn;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MOCK_BIN = path.join(__dirname, 'fixtures', 'mock_upstream.mjs');
+const MOCK_EMPTY_BIN = path.join(__dirname, 'fixtures', 'mock_empty_upstream.mjs');
 
 test.beforeEach(() => {
   _resetForTesting();
@@ -21,6 +24,8 @@ test.beforeEach(() => {
  *   - Tools register under `<prefix>_<originalName>` and forward.
  *   - Resources register with their upstream URI verbatim and forward.
  *   - Prompts register under `<prefix>_<originalName>` and forward.
+ *   - The richer `format` tool's input schema (enum / integer / array / optional) survives the
+ *     JSON-Schema → Zod conversion and a call through it returns the upstream's response.
  *
  * Serial: tests share module-scoped resourceOwners and spawn children — keep teardown
  * deterministic.
@@ -38,7 +43,7 @@ test.serial('mountUpstream namespaces and forwards tools, resources, and prompts
   );
 
   try {
-    t.deepEqual(handle.toolNames, ['mock_echo']);
+    t.deepEqual(handle.toolNames.sort(), ['mock_echo', 'mock_format']);
     t.deepEqual(handle.resourceUris, ['mock://doc']);
     t.deepEqual(handle.promptNames, ['mock_greet']);
 
@@ -51,6 +56,16 @@ test.serial('mountUpstream namespaces and forwards tools, resources, and prompts
     const toolContent = (toolResult.content as Array<{ type: string; text?: string }>)?.[0];
     t.is(toolContent?.type, 'text');
     t.is(toolContent?.text, 'echo: hi');
+
+    // Richer-schema tool: enum + integer + array + optional. Doesn't supply `verbose`, which
+    // the upstream defaults to false. We assert the upstream's default applied (proving the
+    // parent did NOT also apply a default and short-circuit the upstream).
+    const richResult = await handle.client.callTool({
+      name: 'format',
+      arguments: { style: 'short', count: 3, tags: ['a', 'b'] },
+    });
+    const richContent = (richResult.content as Array<{ type: string; text?: string }>)?.[0];
+    t.is(richContent?.text, 'style=short count=3 tags=[a,b] verbose=false');
 
     const readResult = await handle.client.readResource({ uri: 'mock://doc' });
     const resourceContent = (readResult.contents as Array<{ text?: string }>)?.[0];
@@ -66,6 +81,98 @@ test.serial('mountUpstream namespaces and forwards tools, resources, and prompts
   } finally {
     await handle.transport.close();
   }
+});
+
+/**
+ * Verifies a tool call routed through the parent McpServer (rather than calling the child
+ * client directly) actually reaches the upstream and returns its result. This protects against
+ * regressions in the registerTool wiring — the previous test exercises the client; this one
+ * exercises the full parent → registered handler → child path.
+ */
+test.serial('mounted tool is callable through the parent server', async (t) => {
+  const server = new McpServer(
+    { name: 'host', version: '0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  );
+
+  const handle = await mountUpstream(
+    server,
+    { prefix: 'mock', label: 'Mock Upstream', packageName: 'unused' },
+    { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+  );
+
+  // Connect a Client over an in-memory transport pair so we can invoke the parent the same
+  // way an MCP client would.
+  const client = new Client({ name: 'test-client', version: '0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+  try {
+    // tools/list against the parent should include the mounted name (no namespace stripping).
+    const list = await client.listTools();
+    const names = list.tools.map((t) => t.name);
+    t.true(names.includes('mock_echo'), `mock_echo missing from parent: ${names.join(', ')}`);
+
+    const result = await client.callTool({
+      name: 'mock_echo',
+      arguments: { message: 'through-parent' },
+    });
+    const content = (result.content as Array<{ type: string; text?: string }>)?.[0];
+    t.is(content?.text, 'echo: through-parent');
+  } finally {
+    await client.close();
+    await server.close();
+    await handle.transport.close();
+  }
+});
+
+/**
+ * An upstream advertising no capabilities must not blow up — listTools/listResources/listPrompts
+ * are all gated on the corresponding capability, so all three lists should come back empty.
+ */
+test.serial(
+  'mountUpstream against an upstream with no capabilities yields empty lists',
+  async (t) => {
+    const server = new McpServer(
+      { name: 'host', version: '0' },
+      { capabilities: { tools: {}, resources: {}, prompts: {} } }
+    );
+
+    const handle = await mountUpstream(
+      server,
+      { prefix: 'empty', label: 'Empty Upstream', packageName: 'unused' },
+      { binPath: MOCK_EMPTY_BIN, onUpstreamExit: () => {} }
+    );
+
+    try {
+      t.deepEqual(handle.toolNames, []);
+      t.deepEqual(handle.resourceUris, []);
+      t.deepEqual(handle.promptNames, []);
+    } finally {
+      await handle.transport.close();
+    }
+  }
+);
+
+/**
+ * mountUpstreams' duplicate-prefix guard must reject configs that share a prefix BEFORE any
+ * child is spawned, so a typo in the registry never produces a non-deterministically-routed
+ * server.
+ */
+test.serial('mountUpstreams throws on duplicate prefixes in the registry', async (t) => {
+  const server = new McpServer(
+    { name: 'host', version: '0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  );
+
+  await t.throwsAsync(
+    () =>
+      mountUpstreams(server, [
+        { prefix: 'dup', label: 'A', packageName: 'unused' },
+        { prefix: 'dup', label: 'B', packageName: 'unused' },
+      ]),
+    { message: /Duplicate upstream prefix "dup"/ }
+  );
 });
 
 /**

--- a/test/upstreams.test.ts
+++ b/test/upstreams.test.ts
@@ -27,7 +27,7 @@ test.beforeEach(() => {
  *   - The richer `format` tool's input schema (enum / integer / array / optional) survives the
  *     JSON-Schema → Zod conversion and a call through it returns the upstream's response.
  *
- * Serial: tests share module-scoped resourceOwners and spawn children — keep teardown
+ * Serial: tests share module-scoped resourceOwners and spawn children - keep teardown
  * deterministic.
  */
 test.serial('mountUpstream namespaces and forwards tools, resources, and prompts', async (t) => {
@@ -47,7 +47,7 @@ test.serial('mountUpstream namespaces and forwards tools, resources, and prompts
     t.deepEqual(handle.resourceUris, ['mock://doc']);
     t.deepEqual(handle.promptNames, ['mock_greet']);
 
-    // Forward a tool call through the upstream client — this exercises the same path the
+    // Forward a tool call through the upstream client - this exercises the same path the
     // mounted handler uses (server.registerTool's callback delegates to it).
     const toolResult = await handle.client.callTool({
       name: 'echo',
@@ -86,7 +86,7 @@ test.serial('mountUpstream namespaces and forwards tools, resources, and prompts
 /**
  * Verifies a tool call routed through the parent McpServer (rather than calling the child
  * client directly) actually reaches the upstream and returns its result. This protects against
- * regressions in the registerTool wiring — the previous test exercises the client; this one
+ * regressions in the registerTool wiring - the previous test exercises the client; this one
  * exercises the full parent → registered handler → child path.
  */
 test.serial('mounted tool is callable through the parent server', async (t) => {
@@ -127,7 +127,7 @@ test.serial('mounted tool is callable through the parent server', async (t) => {
 });
 
 /**
- * An upstream advertising no capabilities must not blow up — listTools/listResources/listPrompts
+ * An upstream advertising no capabilities must not blow up - listTools/listResources/listPrompts
  * are all gated on the corresponding capability, so all three lists should come back empty.
  */
 test.serial(
@@ -177,7 +177,7 @@ test.serial('mountUpstreams throws on duplicate prefixes in the registry', async
 
 /**
  * Mounts the real React MCP via the registry and asserts its expected tools and resources show
- * up. We don't call its tools — that's the React team's contract — only that the mount plumbing
+ * up. We don't call its tools - that's the React team's contract - only that the mount plumbing
  * sees them.
  */
 test.serial(
@@ -228,7 +228,7 @@ test.serial('mountUpstream throws on resource URI collision across upstreams', a
     { binPath: MOCK_BIN, onUpstreamExit: () => {} }
   );
 
-  // Second mount of the same fixture would re-register `mock://doc` — must throw.
+  // Second mount of the same fixture would re-register `mock://doc` - must throw.
   await t.throwsAsync(
     () =>
       mountUpstream(

--- a/test/upstreams_leak_regression.test.ts
+++ b/test/upstreams_leak_regression.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Regression tests for the two child-process-leak bugs called out in the PR #17 review comment
+ * from NakataCode (2026-08-05):
+ *
+ *   1. `mountUpstreams` leaks already-spawned children when a later mount throws.
+ *   2. `handles` in the entrypoint is `[]` during the mount window, so a shutdown fired
+ *      mid-mount leaves in-flight children orphaned.
+ *
+ * These previously-failing "proof" tests now assert the fixed behavior — flipping either back
+ * would cause a real leak on the same code paths.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import anyTest, { TestFn } from 'ava';
+
+import {
+  mountUpstream,
+  mountUpstreams,
+  markShutdown,
+  _resetForTesting,
+  UPSTREAMS,
+  UpstreamHandle,
+} from '../src/upstreams/index.js';
+
+const test = anyTest as TestFn;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MOCK_BIN = path.join(__dirname, 'fixtures', 'mock_upstream.mjs');
+
+test.beforeEach(() => {
+  _resetForTesting();
+});
+
+/**
+ * Returns true if a process with `pid` is currently alive. `process.kill(pid, 0)` throws
+ * ESRCH when the pid doesn't exist.
+ */
+function isAlive(pid: number | null | undefined): boolean {
+  if (pid == null) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll for `isAlive(pid) === false` for up to `timeoutMs`. The child's 'close' event races the
+ * subsequent kill(pid, 0) syscall — sometimes we observe it dead immediately, sometimes a few
+ * ms later. Poll to avoid a flaky sleep-then-check.
+ */
+async function waitDead(pid: number | null | undefined, timeoutMs = 2000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!isAlive(pid)) return true;
+    await delay(20);
+  }
+  return false;
+}
+
+/**
+ * Issue 1: `mountUpstreams` must not leak already-spawned children when a later mount throws.
+ *
+ * We drive `mountUpstreams` with two specs: the first resolves to the real, installed
+ * `@ui5/webcomponents-react-mcp` package; the second has an unresolvable packageName so
+ * `resolveUpstreamBin` throws before its child is even spawned. Without the fix, the React
+ * child (fully mounted before the failure) stays alive; with the fix, `mountUpstreams`' catch
+ * closes every collected handle before rethrowing.
+ *
+ * The `onHandle` callback captures each handle as it lands so we can observe the leak surface
+ * from outside `mountUpstreams`. This is exactly how src/index.ts uses the callback.
+ */
+test.serial(
+  'mountUpstreams closes already-mounted children when a later mount fails',
+  async (t) => {
+    const reactSpec = UPSTREAMS.find((u) => u.prefix === 'react');
+    t.truthy(reactSpec, 'React entry must exist in UPSTREAMS for this test');
+
+    const server = new McpServer(
+      { name: 'host', version: '0' },
+      { capabilities: { tools: {}, resources: {}, prompts: {} } }
+    );
+
+    const captured: UpstreamHandle[] = [];
+    await t.throwsAsync(() =>
+      mountUpstreams(
+        server,
+        [reactSpec!, { prefix: 'nope', label: 'Nope', packageName: '__does_not_exist__' }],
+        (h) => captured.push(h)
+      )
+    );
+
+    t.is(captured.length, 1, 'first upstream was mounted before the failure');
+    const firstPid = captured[0].transport.pid;
+    t.true(
+      await waitDead(firstPid),
+      `first child (pid ${firstPid}) must be dead after mountUpstreams rejected`
+    );
+  }
+);
+
+/**
+ * Issue 2: During the mount window, the entrypoint's `handles` used to be `[]` — a SIGINT
+ * arriving between "child spawned" and "mountUpstreams resolved" left the child orphaned.
+ *
+ * The fix threads an `onHandle` callback through `mountUpstreams` so the entrypoint sees each
+ * handle as soon as it's connected. Here we replay that exact pattern: start `mountUpstreams`
+ * against a slow second mount, wait until the first `onHandle` has fired, run the shutdown
+ * sequence (markShutdown + close each handle), and assert the first child actually died.
+ *
+ * We inline the outer loop shape rather than calling `mountUpstreams` because `mountUpstreams`
+ * doesn't accept per-spec `binPath` — but the callback contract we're testing is identical.
+ */
+test.serial('mid-mount shutdown closes the child via onHandle callback', async (t) => {
+  const server = new McpServer(
+    { name: 'host', version: '0' },
+    { capabilities: { tools: {}, resources: {}, prompts: {} } }
+  );
+
+  // Mirror of `const handles: UpstreamHandle[] = []` in src/index.ts (with the fix applied).
+  const handles: UpstreamHandle[] = [];
+
+  // Sequential mount: first is our mock; second delays so we can catch the shutdown window
+  // AFTER the first handle has been collected. The delay is simulated by awaiting a promise
+  // we never resolve until the test signals we're done.
+  let releaseSecondMount: () => void = () => {};
+  const secondMountGate = new Promise<void>((resolve) => {
+    releaseSecondMount = resolve;
+  });
+
+  const mountLoop = (async () => {
+    const h1 = await mountUpstream(
+      server,
+      { prefix: 'a', label: 'A', packageName: 'unused' },
+      { binPath: MOCK_BIN, onUpstreamExit: () => {} }
+    );
+    handles.push(h1); // simulates onHandle callback
+    // Gate: don't proceed until the test releases us. Simulates a slow second mount.
+    await secondMountGate;
+    return handles;
+  })();
+
+  // Wait until the first mount has completed and onHandle has fired.
+  while (handles.length === 0) await delay(10);
+
+  // Now simulate SIGINT: run the exact shutdown sequence from src/index.ts.
+  markShutdown();
+  for (const h of handles) {
+    try {
+      h.transport.close();
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // The first child should be dead - shutdown had a handle to close, unlike before the fix.
+  t.is(handles.length, 1, 'onHandle callback populated the shutdown array mid-mount');
+  t.true(
+    await waitDead(handles[0].transport.pid),
+    `child (pid ${handles[0].transport.pid}) must be dead after mid-mount shutdown`
+  );
+
+  // Release the gate and drain the mount loop so the test process exits cleanly.
+  releaseSecondMount();
+  await mountLoop;
+});


### PR DESCRIPTION
## Summary

Closes: https://github.com/UI5/webcomponents-mcp-server/issues/16

Adds an opt-in upstream-mounting layer so this server can spawn another MCP server as a child over stdio and re-publish its tools, resources, and prompts under a configurable name prefix.

The first registered upstream is **`@ui5/webcomponents-react-mcp`** under the `react` prefix. Net effect for users: one install of `@ui5/webcomponents-mcp-server` now also surfaces the React MCP's tools as `react_*`. No breaking change to the existing native surface.

## Why

The Web Components team ships this server. The React team ships their own. Future framework teams (Vue, Angular, …) will ship more. Customers shouldn't need to wire up N servers to get full UI5 webcomponents coverage - they install one MCP and the rest follows.

Adding a future framework MCP becomes a one-entry addition to `src/upstreams/registry.ts` plus the new package as a runtime dependency.

## What changes

| Area | Change |
|---|---|
| `src/upstreams/registry.ts` | `UPSTREAMS` list (one entry today, React). |
| `src/upstreams/mount.ts` | Spawns each upstream via `StdioClientTransport`, lists capabilities, converts JSON Schema → Zod, re-registers tools/resources/prompts on the parent. URI ownership is tracked per mount; cross-upstream collisions fail fast at startup. |
| `src/upstreams/index.ts` | Barrel + `UpstreamHandle` type. |
| `src/index.ts` | Declares `tools`/`resources`/`prompts` capabilities, awaits `mountUpstreams()` before connecting stdio, binds child cleanup to SIGINT/SIGTERM/exit. |
| `package.json` | Adds `@ui5/webcomponents-react-mcp` as a runtime dependency (spawned via `require.resolve`). No other runtime-dep changes. |
| `.gitignore` | Adds `.ab/` (umbrella for A/B-harness output, follow-up). |

## Tests

3 new serial tests in `test/upstreams.test.ts`:

- ✅ Mounts a fixture upstream (`test/fixtures/mock_upstream.mjs`) and asserts tools, resources, and prompts are namespaced and forwarded with the correct prefix.
- ✅ Mounts the **real `@ui5/webcomponents-react-mcp`** child and asserts the expected tools and the `llms.txt` resource appear.
- ✅ Throws fast on cross-upstream resource-URI collisions.

Local run: **41/41 passing** (38 existing + 3 new).

```
✔ upstreams › mountUpstream namespaces and forwards tools, resources, and prompts (106ms)
✔ upstreams › mountUpstream against real React MCP exposes expected tools and llms.txt resource (174ms)
✔ upstreams › mountUpstream throws on resource URI collision across upstreams (223ms)
```

## Compatibility

- **No breaking changes** to existing tool/resource/prompt names.
- Forwarded items use a clear `react_*` prefix; native names stay as-is.
- If the React child fails to spawn or list its capabilities, the parent fails fast with a clear error rather than starting in a half-mounted state.
- Children are bound to the parent's lifecycle (SIGINT/SIGTERM/exit).

## Caveats / known follow-ups

- **One upstream in the registry today.** The whole point is the second is one line; we just haven't shipped it.
- **Hardcoded registry.** No customer-supplied upstreams via config yet.
- **Stdio transport only.** SSE/HTTP-transport upstreams not supported (npm-distributed servers covered today).
- **Names use a double prefix.** The React MCP already namespaces its own tools, so you see `react_react_get_component_api`. Cosmetic, deterministic; can be cleaned up in a follow-up.

## Manual verification

```sh
npm ci
npm run build
npm test          # 41/41 pass
./build/index.js  # boot manually; confirms mount log lines
```


