### PR TITLE
fix: add corporate proxy support using https-proxy-agent (fixes #18)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,6 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
+        "https-proxy-agent": "^9.1.0",
+        "node-fetch": "^3.3.2",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -21,10 +23,10 @@
         "@typescript-eslint/parser": "^8.15.0",
         "ava": "^6.4.1",
         "eslint": "^9.15.0",
+        "nock": "^14.0.15",
         "prettier": "^3.3.3",
         "tsx": "^4.20.6",
         "typescript": "^5.7.2",
-        "undici": "^8.4.1",
         "vite-node": "^3.2.4"
       },
       "engines": {
@@ -843,6 +845,51 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
@@ -883,6 +930,24 @@
         }
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -920,6 +985,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1672,13 +1762,12 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/ajv": {
@@ -2344,6 +2433,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/date-time": {
@@ -3057,6 +3155,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -3193,6 +3314,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -3454,9 +3587,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3495,17 +3628,17 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/iconv-lite": {
@@ -3664,6 +3797,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3782,6 +3922,13 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4100,25 +4247,57 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "node_modules/nock": {
+      "version": "14.0.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "@mswjs/interceptors": "^0.41.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
         }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp-build": {
@@ -4218,6 +4397,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -4515,6 +4701,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4526,6 +4722,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
       }
     },
     "node_modules/punycode": {
@@ -5017,6 +5230,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -5367,16 +5587,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.4.1.tgz",
-      "integrity": "sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -5521,6 +5731,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,6 +24,7 @@
         "prettier": "^3.3.3",
         "tsx": "^4.20.6",
         "typescript": "^5.7.2",
+        "undici": "^8.4.1",
         "vite-node": "^3.2.4"
       },
       "engines": {
@@ -5364,6 +5365,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.4.1.tgz",
+      "integrity": "sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -56,14 +56,16 @@
     "@typescript-eslint/parser": "^8.15.0",
     "ava": "^6.4.1",
     "eslint": "^9.15.0",
+    "nock": "^14.0.15",
     "prettier": "^3.3.3",
     "tsx": "^4.20.6",
     "typescript": "^5.7.2",
-    "undici": "^8.4.1",
     "vite-node": "^3.2.4"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
+    "https-proxy-agent": "^9.1.0",
+    "node-fetch": "^3.3.2",
     "zod": "^3.25.76"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "prettier": "^3.3.3",
     "tsx": "^4.20.6",
     "typescript": "^5.7.2",
+    "undici": "^8.4.1",
     "vite-node": "^3.2.4"
   },
   "dependencies": {

--- a/src/tools/get_component_api/manifest_processor.ts
+++ b/src/tools/get_component_api/manifest_processor.ts
@@ -1,5 +1,5 @@
 import { CustomElementsManifest, NpmPackageData, type ComponentData } from '../../types.js';
-import { USER_AGENT, NPM_REGISTRY_BASE, UNPKG_BASE, makeNpmRequest, getProxyAgent } from '../../utils.js';
+import { USER_AGENT, NPM_REGISTRY_BASE, UNPKG_BASE, makeNpmRequest, proxyFetch } from '../../utils.js';
 import { logger } from '../../logger.js';
 
 // UI5 Web Components packages ordered by priority
@@ -18,11 +18,9 @@ export async function fetchCustomElementsManifest(
     const customElementsPath = packageData.customElements.replace('./', '');
     const manifestUrl = `${UNPKG_BASE}/${packageData.name}@${packageData.version}/${customElementsPath}`;
 
-    const dispatcher = getProxyAgent();
-    const response = await fetch(manifestUrl, {
+    const response = await proxyFetch(manifestUrl, {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
-      dispatcher,
-    } as RequestInit);
+    });
 
     if (!response.ok) return null;
     return (await response.json()) as CustomElementsManifest;

--- a/src/tools/get_component_api/manifest_processor.ts
+++ b/src/tools/get_component_api/manifest_processor.ts
@@ -1,5 +1,5 @@
 import { CustomElementsManifest, NpmPackageData, type ComponentData } from '../../types.js';
-import { USER_AGENT, NPM_REGISTRY_BASE, UNPKG_BASE, makeNpmRequest } from '../../utils.js';
+import { USER_AGENT, NPM_REGISTRY_BASE, UNPKG_BASE, makeNpmRequest, getProxyAgent } from '../../utils.js';
 import { logger } from '../../logger.js';
 
 // UI5 Web Components packages ordered by priority
@@ -18,9 +18,11 @@ export async function fetchCustomElementsManifest(
     const customElementsPath = packageData.customElements.replace('./', '');
     const manifestUrl = `${UNPKG_BASE}/${packageData.name}@${packageData.version}/${customElementsPath}`;
 
+    const dispatcher = getProxyAgent();
     const response = await fetch(manifestUrl, {
       headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
-    });
+      dispatcher,
+    } as RequestInit);
 
     if (!response.ok) return null;
     return (await response.json()) as CustomElementsManifest;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,27 @@
+import { ProxyAgent } from 'undici';
 import { logger } from './logger.js';
 
 export const NPM_REGISTRY_BASE = "https://registry.npmjs.org";
 export const USER_AGENT = "ui5-webc-mcp/1.0";
 export const UNPKG_BASE = "https://unpkg.com";
+
+/**
+ * Returns a ProxyAgent if a proxy URL is detected in environment variables,
+ * or undefined if no proxy is configured.
+ * Checks HTTPS_PROXY, https_proxy, HTTP_PROXY, and http_proxy in order.
+ */
+export function getProxyAgent(): ProxyAgent | undefined {
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy;
+  if (proxyUrl) {
+    logger.debug(`Using proxy: ${proxyUrl}`);
+    return new ProxyAgent(proxyUrl);
+  }
+  return undefined;
+}
 
 export async function makeNpmRequest<T>(url: string): Promise<T | null> {
   const headers = {
@@ -11,7 +30,8 @@ export async function makeNpmRequest<T>(url: string): Promise<T | null> {
   };
 
   try {
-    const response = await fetch(url, { headers });
+    const dispatcher = getProxyAgent();
+    const response = await fetch(url, { headers, dispatcher } as RequestInit);
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { ProxyAgent } from 'undici';
+import fetch, { type RequestInit as NodeFetchRequestInit } from 'node-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { logger } from './logger.js';
 
 export const NPM_REGISTRY_BASE = "https://registry.npmjs.org";
@@ -6,11 +7,11 @@ export const USER_AGENT = "ui5-webc-mcp/1.0";
 export const UNPKG_BASE = "https://unpkg.com";
 
 /**
- * Returns a ProxyAgent if a proxy URL is detected in environment variables,
- * or undefined if no proxy is configured.
+ * Returns an HttpsProxyAgent if a proxy URL is detected in environment
+ * variables, or undefined if no proxy is configured.
  * Checks HTTPS_PROXY, https_proxy, HTTP_PROXY, and http_proxy in order.
  */
-export function getProxyAgent(): ProxyAgent | undefined {
+export function getProxyAgent(): HttpsProxyAgent<string> | undefined {
   const proxyUrl =
     process.env.HTTPS_PROXY ||
     process.env.https_proxy ||
@@ -18,9 +19,25 @@ export function getProxyAgent(): ProxyAgent | undefined {
     process.env.http_proxy;
   if (proxyUrl) {
     logger.debug(`Using proxy: ${proxyUrl}`);
-    return new ProxyAgent(proxyUrl);
+    return new HttpsProxyAgent<string>(proxyUrl);
   }
   return undefined;
+}
+
+/**
+ * Proxy-aware fetch using node-fetch + https-proxy-agent.
+ * Routes requests through the configured HTTP/HTTPS proxy when present.
+ */
+export async function proxyFetch(
+  url: string,
+  init?: { headers?: Record<string, string> }
+): ReturnType<typeof fetch> {
+  const agent = getProxyAgent();
+  const fetchInit: NodeFetchRequestInit = { ...init };
+  if (agent) {
+    fetchInit.agent = agent;
+  }
+  return fetch(url, fetchInit);
 }
 
 export async function makeNpmRequest<T>(url: string): Promise<T | null> {
@@ -30,8 +47,7 @@ export async function makeNpmRequest<T>(url: string): Promise<T | null> {
   };
 
   try {
-    const dispatcher = getProxyAgent();
-    const response = await fetch(url, { headers, dispatcher } as RequestInit);
+    const response = await proxyFetch(url, { headers });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/test/tools/manifest_processor.test.ts
+++ b/test/tools/manifest_processor.test.ts
@@ -1,4 +1,5 @@
 import anyTest, { TestFn } from 'ava';
+import nock from 'nock';
 import {
   formatComponentAPI,
   findComponentInManifest,
@@ -204,11 +205,9 @@ test('fetchCustomElementsManifest returns null if no customElements field', asyn
 
 test('fetchCustomElementsManifest fetches manifest successfully', async (t) => {
   const mockManifestResponse = { modules: [] };
-  global.fetch = async () =>
-    ({
-      ok: true,
-      json: async () => mockManifestResponse,
-    }) as Response;
+  nock('https://unpkg.com')
+    .get('/@ui5/webcomponents@2.0.0/dist/custom-elements.json')
+    .reply(200, mockManifestResponse);
 
   const packageData: NpmPackageData = {
     name: '@ui5/webcomponents',
@@ -221,11 +220,9 @@ test('fetchCustomElementsManifest fetches manifest successfully', async (t) => {
 });
 
 test('fetchCustomElementsManifest handles fetch errors', async (t) => {
-  global.fetch = async () =>
-    ({
-      ok: false,
-      status: 404,
-    }) as Response;
+  nock('https://unpkg.com')
+    .get('/@ui5/webcomponents@2.0.0/dist/custom-elements.json')
+    .reply(404);
 
   const packageData: NpmPackageData = {
     name: '@ui5/webcomponents',
@@ -238,9 +235,9 @@ test('fetchCustomElementsManifest handles fetch errors', async (t) => {
 });
 
 test('fetchCustomElementsManifest handles network errors', async (t) => {
-  global.fetch = async () => {
-    throw new Error('Network error');
-  };
+  nock('https://unpkg.com')
+    .get('/@ui5/webcomponents@2.0.0/dist/custom-elements.json')
+    .replyWithError('Network error');
 
   const packageData: NpmPackageData = {
     name: '@ui5/webcomponents',

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import anyTest, { TestFn } from 'ava';
-import { createTextResponse, handleToolError } from '../src/utils.js';
+import { createTextResponse, handleToolError, getProxyAgent } from '../src/utils.js';
 
 const test = anyTest as TestFn;
 
@@ -36,4 +36,51 @@ test('handleToolError formats non-Error objects', (t) => {
 
   t.is(result.content[0].type, 'text');
   t.true(result.content[0].text.includes('Request failed'));
+});
+
+// getProxyAgent tests
+const PROXY_ENV_VARS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'];
+
+function clearProxyEnv(): void {
+  for (const key of PROXY_ENV_VARS) {
+    delete process.env[key];
+  }
+}
+
+test.serial('getProxyAgent returns undefined when no proxy env vars are set', (t) => {
+  clearProxyEnv();
+  t.is(getProxyAgent(), undefined);
+});
+
+test.serial('getProxyAgent returns an agent when HTTPS_PROXY is set', (t) => {
+  clearProxyEnv();
+  process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
+  const agent = getProxyAgent();
+  t.truthy(agent);
+  t.is(agent!.proxy.hostname, 'proxy.example.com');
+  t.is(agent!.proxy.port, '8080');
+  delete process.env.HTTPS_PROXY;
+});
+
+test.serial('getProxyAgent respects priority: HTTPS_PROXY > https_proxy > HTTP_PROXY > http_proxy', (t) => {
+  // On Windows, env var names are case-insensitive, so HTTPS_PROXY and
+  // https_proxy refer to the same variable. We test each fallback level
+  // in isolation to avoid this OS-level quirk.
+
+  // Highest priority: HTTPS_PROXY
+  clearProxyEnv();
+  process.env.HTTPS_PROXY = 'http://highest-priority:4444';
+  t.is(getProxyAgent()!.proxy.hostname, 'highest-priority');
+
+  // Fallback: HTTP_PROXY (skip https_proxy on Windows due to case-insensitivity)
+  clearProxyEnv();
+  process.env.HTTP_PROXY = 'http://mid-priority:2222';
+  t.is(getProxyAgent()!.proxy.hostname, 'mid-priority');
+
+  // Last resort: http_proxy
+  clearProxyEnv();
+  process.env.http_proxy = 'http://low-priority:1111';
+  t.is(getProxyAgent()!.proxy.hostname, 'low-priority');
+
+  clearProxyEnv();
 });


### PR DESCRIPTION
## Summary

The MCP server originally does not work behind a corporate proxy because Node.js native `fetch()` does not respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables. This PR adds proxy support using `https-proxy-agent` and `node-fetch`, enabling the server to function correctly in proxied environments.

### Commits

- **`bf73e5e`** - Initial proxy support: Added `getProxyAgent()` that reads proxy configuration from `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy` environment variables.
- **`20f6bca`** - Replaced `undici` with `node-fetch` + `https-proxy-agent` for robust proxy support. Added `proxyFetch()` wrapper, comprehensive unit tests with `nock`, and proper env var priority handling.

### Key Changes
- Added `node-fetch` and `https-proxy-agent` as runtime dependencies; removed `undici`
- Added `nock` as dev dependency for clean HTTP mocking in tests
- `getProxyAgent()` returns an `HttpsProxyAgent` based on proxy env vars
- New `proxyFetch()` wrapper routes all outbound requests through proxy when configured
- Environment variable priority: `HTTPS_PROXY` > `https_proxy` > `HTTP_PROXY` > `http_proxy`
- Updated `manifest_processor` to use `proxyFetch` instead of raw `fetch`
- Rewrote `manifest_processor` tests to use `nock` instead of mocking `global.fetch`
- Added `getProxyAgent` unit tests with proper env var isolation

Fixes #18