### PR TITLE
fix(get_component_api): surface deprecated and experimental API flags

### DIFF
--- a/src/tools/get_component_api/get_component_api.ts
+++ b/src/tools/get_component_api/get_component_api.ts
@@ -5,12 +5,13 @@ import { createTextResponse, handleToolError } from '../../utils.js';
 type GetComponentAPIToolPayload = {
   componentName: string;
   version?: string;
+  hideDeprecated?: boolean;
 };
 
 export const getComponentApiTool = {
   name: 'get_component_api',
   description:
-    'Get API documentation for a specific UI5 Web Component from @ui5/webcomponents, @ui5/webcomponents-fiori, @ui5/webcomponents-ai',
+    'Get API documentation for a specific UI5 Web Component from @ui5/webcomponents, @ui5/webcomponents-fiori, @ui5/webcomponents-ai. Deprecated and experimental members are surfaced with warnings so consumers can avoid them.',
   inputSchema: {
     componentName: z
       .string()
@@ -22,8 +23,19 @@ export const getComponentApiTool = {
       .describe(
         'Version of the UI5 Web Components packages (e.g., "2.12.0"). If not provided, the latest version will be used.'
       ),
+    hideDeprecated: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'When true, deprecated attributes, slots, events and methods are filtered out entirely. Defaults to false so deprecations are visible with a warning.'
+      ),
   },
-  handler: async ({ componentName, version = 'latest' }: GetComponentAPIToolPayload) => {
+  handler: async ({
+    componentName,
+    version = 'latest',
+    hideDeprecated = false,
+  }: GetComponentAPIToolPayload) => {
     try {
       if (!/^[\da-zA-Z.\-]+$/.test(version)) {
         return createTextResponse(
@@ -48,7 +60,7 @@ export const getComponentApiTool = {
         );
       }
 
-      return createTextResponse(formatComponentAPI(componentData));
+      return createTextResponse(formatComponentAPI(componentData, { hideDeprecated }));
     } catch (error) {
       return handleToolError(error, `Error retrieving API documentation for ${componentName}`);
     }

--- a/src/tools/get_component_api/manifest_processor.ts
+++ b/src/tools/get_component_api/manifest_processor.ts
@@ -1,4 +1,12 @@
-import { CustomElementsManifest, NpmPackageData, type ComponentData } from '../../types.js';
+import {
+  CustomElementsManifest,
+  NpmPackageData,
+  type ComponentAttribute,
+  type ComponentData,
+  type ComponentEvent,
+  type ComponentMember,
+  type ComponentSlot,
+} from '../../types.js';
 import { USER_AGENT, NPM_REGISTRY_BASE, UNPKG_BASE, makeNpmRequest } from '../../utils.js';
 import { logger } from '../../logger.js';
 
@@ -8,6 +16,10 @@ export const UI5_PACKAGES = [
   '@ui5/webcomponents-fiori',
   '@ui5/webcomponents-ai',
 ];
+
+export interface FormatOptions {
+  hideDeprecated?: boolean;
+}
 
 export async function fetchCustomElementsManifest(
   packageData: NpmPackageData
@@ -73,6 +85,8 @@ export function findComponentInManifest(
         name: declaration.name || componentName,
         tagName: declaration.tagName || componentName,
         description: declaration.description || `The ${componentName} component.`,
+        deprecated: declaration.deprecated,
+        _ui5experimental: declaration._ui5experimental,
         attributes: declaration.attributes || [],
         slots: declaration.slots || [],
         events: declaration.events || [],
@@ -84,48 +98,109 @@ export function findComponentInManifest(
   return null;
 }
 
+// Build the "⚠ DEPRECATED" / "🧪 EXPERIMENTAL" markers for a member. Returns an
+// array of markdown lines to insert after the member heading. Empty when the
+// member carries no flags.
+function stabilityMarkers(item: {
+  deprecated?: string | boolean;
+  _ui5experimental?: string | boolean;
+}): string[] {
+  const lines: string[] = [];
+
+  if (item.deprecated !== undefined && item.deprecated !== false) {
+    const reason = typeof item.deprecated === 'string' ? item.deprecated : '';
+    lines.push(
+      reason
+        ? `- **⚠ DEPRECATED:** ${reason}`
+        : '- **⚠ DEPRECATED:** Do not use in new code.'
+    );
+  }
+
+  if (item._ui5experimental !== undefined && item._ui5experimental !== false) {
+    const note = typeof item._ui5experimental === 'string' ? item._ui5experimental : '';
+    lines.push(
+      note
+        ? `- **🧪 EXPERIMENTAL:** ${note}`
+        : '- **🧪 EXPERIMENTAL:** API may change without notice.'
+    );
+  }
+
+  return lines;
+}
+
+function isDeprecated(item: { deprecated?: string | boolean }): boolean {
+  return item.deprecated !== undefined && item.deprecated !== false;
+}
+
+function filterDeprecated<
+  T extends { deprecated?: string | boolean },
+>(items: T[] | undefined, hide: boolean): T[] | undefined {
+  if (!items || !hide) return items;
+  return items.filter((i) => !isDeprecated(i));
+}
+
 // Helper function to format component API data
-export function formatComponentAPI(component: ComponentData): string {
+export function formatComponentAPI(
+  component: ComponentData,
+  options: FormatOptions = {}
+): string {
+  const hide = options.hideDeprecated === true;
   const sections = [`# ${component.name || component.tagName} API Reference`];
+
+  // Component-level stability markers appear right below the title so the
+  // reader (and the LLM) sees them before anything else.
+  const componentMarkers = stabilityMarkers(component);
+  if (componentMarkers.length) {
+    sections.push('\n## Stability');
+    sections.push(...componentMarkers);
+  }
 
   if (component.description) {
     sections.push(`\n## Description\n${component.description}`);
   }
 
-  if (component.attributes?.length) {
+  const attributes = filterDeprecated<ComponentAttribute>(component.attributes, hide);
+  if (attributes?.length) {
     sections.push('\n## Properties/Attributes');
-    component.attributes.forEach((attr) => {
+    attributes.forEach((attr) => {
       sections.push(`\n### ${attr.name}`);
+      sections.push(...stabilityMarkers(attr));
       if (attr.type?.text) sections.push(`- **Type:** ${attr.type.text}`);
       if (attr.description) sections.push(`- **Description:** ${attr.description}`);
       if (attr.default) sections.push(`- **Default:** ${attr.default}`);
     });
   }
 
-  if (component.slots?.length) {
+  const slots = filterDeprecated<ComponentSlot>(component.slots, hide);
+  if (slots?.length) {
     sections.push('\n## Slots');
-    component.slots.forEach((slot) => {
+    slots.forEach((slot) => {
       sections.push(`\n### ${slot.name || 'default'}`);
+      sections.push(...stabilityMarkers(slot));
       if (slot.description) sections.push(`- **Description:** ${slot.description}`);
     });
   }
 
-  if (component.events?.length) {
+  const events = filterDeprecated<ComponentEvent>(component.events, hide);
+  if (events?.length) {
     sections.push('\n## Events');
-    component.events.forEach((event) => {
+    events.forEach((event) => {
       sections.push(`\n### ${event.name}`);
+      sections.push(...stabilityMarkers(event));
       if (event.type?.text) sections.push(`- **Type:** ${event.type.text}`);
       if (event.description) sections.push(`- **Description:** ${event.description}`);
     });
   }
 
-  const publicMethods = component.members?.filter(
-    (m) => m.kind === 'method' && !m.name.startsWith('_')
+  const publicMethods = filterDeprecated<ComponentMember>(
+    component.members?.filter((m) => m.kind === 'method' && !m.name.startsWith('_')),
+    hide
   );
   if (publicMethods?.length) {
     sections.push('\n## Methods');
     publicMethods.forEach((method) => {
       sections.push(`\n### ${method.name}()`);
+      sections.push(...stabilityMarkers(method));
       if (method.type?.text) sections.push(`- **Returns:** ${method.type.text}`);
       if (method.description) sections.push(`- **Description:** ${method.description}`);
     });
@@ -133,4 +208,3 @@ export function formatComponentAPI(component: ComponentData): string {
 
   return sections.join('\n');
 }
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,29 +1,47 @@
+// Deprecation and experimental flags follow the Custom Elements Manifest (CEM) shape.
+// - `deprecated`: either a string reason (preferred) or `true` for a generic marker.
+// - `_ui5experimental`: UI5-specific flag; string note or `true` when marked
+//   experimental in JSDoc. Read defensively so the server surfaces it as soon as
+//   upstream starts publishing it.
+type DeprecatedFlag = string | boolean;
+type ExperimentalFlag = string | boolean;
+
 export interface CustomElementsManifest {
     modules?: Array<{
         declarations?: Array<{
             description?: string;
             tagName?: string;
             name?: string;
+            deprecated?: DeprecatedFlag;
+            _ui5experimental?: ExperimentalFlag;
             attributes?: Array<{
                 name: string;
                 type?: { text: string };
                 description?: string;
                 default?: string;
+                deprecated?: DeprecatedFlag;
+                _ui5experimental?: ExperimentalFlag;
             }>;
             slots?: Array<{
                 name: string;
                 description?: string;
+                deprecated?: DeprecatedFlag;
+                _ui5experimental?: ExperimentalFlag;
             }>;
             events?: Array<{
                 name: string;
                 type?: { text: string };
                 description?: string;
+                deprecated?: DeprecatedFlag;
+                _ui5experimental?: ExperimentalFlag;
             }>;
             members?: Array<{
                 name: string;
                 kind: string;
                 type?: { text: string };
                 description?: string;
+                deprecated?: DeprecatedFlag;
+                _ui5experimental?: ExperimentalFlag;
             }>;
         }>;
     }>;
@@ -34,17 +52,23 @@ export interface ComponentAttribute {
     type?: { text: string };
     description?: string;
     default?: string;
+    deprecated?: DeprecatedFlag;
+    _ui5experimental?: ExperimentalFlag;
 }
 
 export interface ComponentSlot {
     name: string;
     description?: string;
+    deprecated?: DeprecatedFlag;
+    _ui5experimental?: ExperimentalFlag;
 }
 
 export interface ComponentEvent {
     name: string;
     type?: { text: string };
     description?: string;
+    deprecated?: DeprecatedFlag;
+    _ui5experimental?: ExperimentalFlag;
 }
 
 export interface ComponentMember {
@@ -52,12 +76,16 @@ export interface ComponentMember {
     kind: string;
     type?: { text: string };
     description?: string;
+    deprecated?: DeprecatedFlag;
+    _ui5experimental?: ExperimentalFlag;
 }
 
 export interface ComponentData {
     name: string;
     tagName: string;
     description: string;
+    deprecated?: DeprecatedFlag;
+    _ui5experimental?: ExperimentalFlag;
     attributes?: ComponentAttribute[];
     slots?: ComponentSlot[];
     events?: ComponentEvent[];

--- a/test/tools/get_component_api.test.ts
+++ b/test/tools/get_component_api.test.ts
@@ -9,7 +9,7 @@ test.afterEach(() => {
   global.fetch = originalFetch;
 });
 
-test('normalizes Button to ui5-button', async (t) => {
+test.serial('normalizes Button to ui5-button', async (t) => {
   global.fetch = async () => ({ ok: false, status: 404 }) as Response;
 
   const result = await getComponentApiTool.handler({
@@ -20,7 +20,7 @@ test('normalizes Button to ui5-button', async (t) => {
   t.true(result.content[0].text.includes('ui5-button'));
 });
 
-test('normalizes AvatarGroup to ui5-avatar-group', async (t) => {
+test.serial('normalizes AvatarGroup to ui5-avatar-group', async (t) => {
   global.fetch = async () => ({ ok: false, status: 404 }) as Response;
 
   const result = await getComponentApiTool.handler({
@@ -31,7 +31,7 @@ test('normalizes AvatarGroup to ui5-avatar-group', async (t) => {
   t.true(result.content[0].text.includes('ui5-avatar-group'));
 });
 
-test('returns not found for invalid component', async (t) => {
+test.serial('returns not found for invalid component', async (t) => {
   global.fetch = async () => ({ ok: false, status: 404 }) as Response;
 
   const result = await getComponentApiTool.handler({
@@ -42,7 +42,7 @@ test('returns not found for invalid component', async (t) => {
   t.true(result.content[0].text.includes('not found'));
 });
 
-test('blocks version with path traversal', async (t) => {
+test.serial('blocks version with path traversal', async (t) => {
   const result = await getComponentApiTool.handler({
     componentName: 'Button',
     version: '../../express',
@@ -51,7 +51,7 @@ test('blocks version with path traversal', async (t) => {
   t.true(result.content[0].text.includes('Access denied'));
 });
 
-test('blocks version with slashes', async (t) => {
+test.serial('blocks version with slashes', async (t) => {
   const result = await getComponentApiTool.handler({
     componentName: 'Button',
     version: 'latest/../../lodash',
@@ -60,7 +60,7 @@ test('blocks version with slashes', async (t) => {
   t.true(result.content[0].text.includes('Access denied'));
 });
 
-test('allows valid semver version', async (t) => {
+test.serial('allows valid semver version', async (t) => {
   global.fetch = async () => ({ ok: false, status: 404 }) as Response;
 
   const result = await getComponentApiTool.handler({
@@ -71,7 +71,7 @@ test('allows valid semver version', async (t) => {
   t.false(result.content[0].text.includes('Access denied'));
 });
 
-test('allows valid prerelease version', async (t) => {
+test.serial('allows valid prerelease version', async (t) => {
   global.fetch = async () => ({ ok: false, status: 404 }) as Response;
 
   const result = await getComponentApiTool.handler({
@@ -80,4 +80,110 @@ test('allows valid prerelease version', async (t) => {
   });
 
   t.false(result.content[0].text.includes('Access denied'));
+});
+
+// End-to-end: fake CEM containing a deprecated attribute, verify the handler
+// surfaces the warning and that hideDeprecated removes it.
+test.serial('surfaces a deprecation warning end-to-end', async (t) => {
+  const fakeManifest = {
+    modules: [
+      {
+        declarations: [
+          {
+            name: 'TableRowAction',
+            tagName: 'ui5-table-row-action',
+            description: 'Row action.',
+            attributes: [
+              {
+                name: 'interactive',
+                type: { text: 'boolean' },
+                description: 'Whether interactive.',
+                deprecated: 'Set `mode="Interactive"` instead.',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  global.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('registry.npmjs.org')) {
+      return {
+        ok: true,
+        json: async () => ({
+          name: '@ui5/webcomponents',
+          version: '2.25.0',
+          customElements: 'dist/custom-elements.json',
+        }),
+      } as Response;
+    }
+    if (u.includes('unpkg.com')) {
+      return { ok: true, json: async () => fakeManifest } as Response;
+    }
+    return { ok: false, status: 404 } as Response;
+  };
+
+  const result = await getComponentApiTool.handler({
+    componentName: 'ui5-table-row-action',
+    version: 'latest',
+  });
+
+  t.true(result.content[0].text.includes('**⚠ DEPRECATED:**'));
+  t.true(result.content[0].text.includes('Set `mode="Interactive"` instead.'));
+});
+
+test.serial('hideDeprecated removes deprecated members from output end-to-end', async (t) => {
+  const fakeManifest = {
+    modules: [
+      {
+        declarations: [
+          {
+            name: 'TableRowAction',
+            tagName: 'ui5-table-row-action',
+            description: 'Row action.',
+            attributes: [
+              {
+                name: 'interactive',
+                type: { text: 'boolean' },
+                deprecated: 'gone',
+              },
+              {
+                name: 'text',
+                type: { text: 'string' },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  global.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('registry.npmjs.org')) {
+      return {
+        ok: true,
+        json: async () => ({
+          name: '@ui5/webcomponents',
+          version: '2.25.0',
+          customElements: 'dist/custom-elements.json',
+        }),
+      } as Response;
+    }
+    if (u.includes('unpkg.com')) {
+      return { ok: true, json: async () => fakeManifest } as Response;
+    }
+    return { ok: false, status: 404 } as Response;
+  };
+
+  const result = await getComponentApiTool.handler({
+    componentName: 'ui5-table-row-action',
+    version: 'latest',
+    hideDeprecated: true,
+  });
+
+  t.false(result.content[0].text.includes('### interactive'));
+  t.true(result.content[0].text.includes('### text'));
 });

--- a/test/tools/manifest_processor.test.ts
+++ b/test/tools/manifest_processor.test.ts
@@ -252,3 +252,152 @@ test('fetchCustomElementsManifest handles network errors', async (t) => {
   t.is(result, null);
 });
 
+// ---------------------------------------------------------------------------
+// Deprecated / experimental flag surfacing
+// ---------------------------------------------------------------------------
+
+// Mirrors the shape of the real @ui5/webcomponents CEM: `deprecated` is a
+// string reason on individual attributes/slots/events/members. We also cover a
+// component-level flag and the `_ui5experimental` field for future-proofing.
+const mockFlaggedComponent: ComponentData = {
+  name: 'TableRowAction',
+  tagName: 'ui5-table-row-action',
+  description: 'Row action inside a Table.',
+  attributes: [
+    {
+      name: 'interactive',
+      type: { text: 'boolean' },
+      description: 'Whether the action is interactive.',
+      deprecated: 'Set `mode="Interactive"` instead for the same functionality.',
+    },
+    {
+      name: 'text',
+      type: { text: 'string' },
+      description: 'Action label.',
+    },
+  ],
+  slots: [
+    {
+      name: 'icon',
+      description: 'Icon slot.',
+      deprecated: true,
+    },
+  ],
+  events: [
+    {
+      name: 'click',
+      type: { text: 'CustomEvent' },
+      description: 'Fired on click.',
+      _ui5experimental: 'Event payload may change.',
+    },
+  ],
+  members: [
+    {
+      name: 'focus',
+      kind: 'method',
+      type: { text: 'void' },
+      description: 'Focus the action.',
+      _ui5experimental: true,
+    },
+    {
+      name: 'oldMethod',
+      kind: 'method',
+      description: 'Legacy method.',
+      deprecated: 'Use focus() instead.',
+    },
+  ],
+};
+
+test('formatComponentAPI renders a deprecation warning with reason on attributes', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent);
+  t.true(result.includes('### interactive'));
+  t.true(result.includes('**⚠ DEPRECATED:**'));
+  t.true(result.includes('Set `mode="Interactive"` instead for the same functionality.'));
+});
+
+test('formatComponentAPI renders a generic deprecation marker when reason is `true`', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent);
+  t.true(result.includes('### icon'));
+  t.true(result.includes('**⚠ DEPRECATED:** Do not use in new code.'));
+});
+
+test('formatComponentAPI renders an experimental marker with note on events', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent);
+  t.true(result.includes('### click'));
+  t.true(result.includes('**🧪 EXPERIMENTAL:** Event payload may change.'));
+});
+
+test('formatComponentAPI renders a generic experimental marker when flag is `true`', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent);
+  t.true(result.includes('### focus()'));
+  t.true(result.includes('**🧪 EXPERIMENTAL:** API may change without notice.'));
+});
+
+test('formatComponentAPI renders deprecation warnings on methods', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent);
+  t.true(result.includes('### oldMethod()'));
+  t.true(result.includes('Use focus() instead.'));
+});
+
+test('formatComponentAPI renders a top-level Stability section when the whole component is flagged', (t) => {
+  const flagged: ComponentData = {
+    name: 'ExperimentalWidget',
+    tagName: 'ui5-experimental-widget',
+    description: 'Experimental widget.',
+    _ui5experimental: 'Whole component is a preview.',
+  };
+  const result = formatComponentAPI(flagged);
+  t.true(result.includes('## Stability'));
+  t.true(result.includes('Whole component is a preview.'));
+});
+
+test('formatComponentAPI hides deprecated items when hideDeprecated is true', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent, { hideDeprecated: true });
+  // Deprecated attribute, slot and method should be gone entirely.
+  t.false(result.includes('### interactive'));
+  t.false(result.includes('### icon'));
+  t.false(result.includes('### oldMethod()'));
+  // Non-deprecated members remain.
+  t.true(result.includes('### text'));
+  t.true(result.includes('### focus()'));
+});
+
+test('formatComponentAPI keeps deprecated items visible by default', (t) => {
+  const result = formatComponentAPI(mockFlaggedComponent);
+  t.true(result.includes('### interactive'));
+  t.true(result.includes('### oldMethod()'));
+});
+
+test('findComponentInManifest preserves deprecated and experimental flags', (t) => {
+  const manifest: CustomElementsManifest = {
+    modules: [
+      {
+        declarations: [
+          {
+            name: 'TableRowAction',
+            tagName: 'ui5-table-row-action',
+            description: 'Row action.',
+            attributes: [
+              {
+                name: 'interactive',
+                type: { text: 'boolean' },
+                deprecated: 'Use mode="Interactive".',
+              },
+            ],
+            events: [
+              {
+                name: 'click',
+                _ui5experimental: true,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const result = findComponentInManifest(manifest, 'ui5-table-row-action');
+  t.truthy(result);
+  t.is(result?.attributes?.[0].deprecated, 'Use mode="Interactive".');
+  t.is(result?.events?.[0]._ui5experimental, true);
+});
+


### PR DESCRIPTION
## Problem

The server was dropping `deprecated` and `_ui5experimental` fields from the CEM before returning the API reference. LLMs then confidently recommended retired APIs. Concrete case: `ui5-avatar`'s `interactive` property (retired in 2.20) already ships with a `@deprecated` reason in the published CEM, but the reason never made it into the tool response.

## Changes

- `types.ts`: add `deprecated?: string | boolean` and `_ui5experimental?: string | boolean` to the manifest and component types.
- `manifest_processor.ts`: pass flags through in `findComponentInManifest`, and render `⚠ DEPRECATED: <reason>` and `🧪 EXPERIMENTAL: <note>` markers next to attributes, slots, events, methods. Component-level flags surface as a `## Stability` section.
- New optional `hideDeprecated: boolean` argument on the tool (default `false`) — when true, deprecated members are filtered out entirely.

## Tests

Unit tests cover string and boolean values for both flags, the `hideDeprecated` filter, component-level stability, and flag pass-through. Two end-to-end handler tests with a mocked CEM confirm the wiring. Existing tests using `global.fetch` were converted to `test.serial` because they mutate a shared global.

## Manual verification

Smoke-tested against `@ui5/webcomponents@latest` (2.25.0). Calling `get_component_api` for `ui5-avatar` now returns:

```
### interactive
- **⚠ DEPRECATED:** Set `mode="Interactive"` instead for the same functionality with proper accessibility.
- **Type:** boolean
```

With `hideDeprecated: true`, the `interactive` heading is gone.